### PR TITLE
Update upload_with_authentication.py

### DIFF
--- a/python/upload_with_authentication.py
+++ b/python/upload_with_authentication.py
@@ -34,7 +34,7 @@ USE UPLOAD.PY INSTEAD.
 '''
 
 
-MAPILLARY_UPLOAD_URL = "https://mapillary.uploads.manual.images.s3-eu-west-1.amazonaws.com"
+MAPILLARY_UPLOAD_URL = "https://s3-eu-west-1.amazonaws.com/mapillary.uploads.manual.images"
 NUMBER_THREADS = 4
 MOVE_FILES = False
 


### PR DESCRIPTION
Changed upload URL to fix issue with extended SSL certificate checking in Python 2.7.9 as outlined here:
https://github.com/mapillary/mapillary_issues/issues/512#issuecomment-69647516
Fix proposed by user wimh works.