### PR TITLE
Better argv usage

### DIFF
--- a/python/add_fix_dates.py
+++ b/python/add_fix_dates.py
@@ -51,8 +51,8 @@ if __name__ == '__main__':
     '''
 
     if len(sys.argv) != 4:
-        print("Usage: python add_fix_dates.py images-path starttime (yyyy-mm-dd hh:mm:ss) increment-in-seconds")
-        raise IOError("Bad input parameters.")
+        sys.exit("Usage: %s images-path starttime (yyyy-mm-dd hh:mm:ss) increment-in-seconds" % sys.argv[0])
+
     path = sys.argv[1]
     start_time = sys.argv[2]
     time_offset = int(sys.argv[3])

--- a/python/add_mapillary_tag_from_exif.py
+++ b/python/add_mapillary_tag_from_exif.py
@@ -128,10 +128,9 @@ if __name__ == '__main__':
     # print resp
 
     args = sys.argv
-    print args
     if len(args) < 2 or len(args) > 3:
-        print("Usage: python add_mapillary_tag_from_exif.py root_path [sequence_id]")
-        raise IOError("Bad input parameters.")
+        sys.exit("Usage: %s root_path [sequence_id]" % args[0])
+
     path = args[1]
 
     if path.lower().endswith(".jpg"):

--- a/python/add_project.py
+++ b/python/add_project.py
@@ -23,8 +23,7 @@ if __name__ == '__main__':
 
 
     if len(sys.argv) != 3:
-        print("Usage: python add_project.py path 'project name'")
-        raise IOError("Bad input parameters.")
+        sys.exit("Usage: %s path 'project name'" % sys.argv[0])
 
     path = sys.argv[1]
     project_name = sys.argv[2]

--- a/python/download_images.py
+++ b/python/download_images.py
@@ -68,13 +68,10 @@ if __name__ == '__main__':
 
     # handle command line parameters
     if len(sys.argv) < 5:
-        print("Usage: python download_images.py min_lat max_lat min_lon max_lon max_results(optional)")
-
-    try:
-        min_lat, max_lat, min_lon, max_lon = sys.argv[1:5]
-    except:
-        print("Usage: python download_images.py min_lat max_lat min_lon max_lon max_results(optional)")
-        raise IOError("Bad input parameters.")
+        try:
+            min_lat, max_lat, min_lon, max_lon = sys.argv[1:5]
+        except:
+            sys.exit("Usage: %s min_lat max_lat min_lon max_lon [max_results]" % sys.argv[0])
 
     if len(sys.argv)==6:
         max_results = sys.argv[5]

--- a/python/geotag_from_gpx.py
+++ b/python/geotag_from_gpx.py
@@ -202,9 +202,9 @@ if __name__ == '__main__':
     then the offset is 2.
     '''
 
-    if len(sys.argv) > 4:
-        print("Usage: python geotag_from_gpx.py path gpx_file time_offset")
-        raise IOError("Bad input parameters.")
+    if len(sys.argv) < 3 or len(sys.argv) > 4:
+        sys.exit("Usage: %s path gpx_file [time_offset]" % sys.argv[0])
+
     path = sys.argv[1]
     gpx_filename = sys.argv[2]
 

--- a/python/interpolate_direction.py
+++ b/python/interpolate_direction.py
@@ -84,9 +84,9 @@ def write_direction_to_image(filename, direction):
 
 
 if __name__ == '__main__':
-    if len(sys.argv) > 3:
-        print("Usage: python interpolate_direction.py path [offset_angle]")
-        raise IOError("Bad input parameters.")
+    if len(sys.argv) < 2 or len(sys.argv) > 3:
+        print("Usage: %s path [offset_angle]" % sys.argv[0])
+
     path = sys.argv[1]
     
     # offset angle, relative to camera position, clockwise is positive

--- a/python/time_split.py
+++ b/python/time_split.py
@@ -74,9 +74,8 @@ if __name__ == '__main__':
     Use from command line as: python time_split.py path cutoff_time
     '''
 
-    if len(sys.argv) > 3:
-        print("Usage: python time_split.py path cutoff_time")
-        raise IOError("Bad input parameters.")
+    if len(sys.argv) < 2 or len(sys.argv) > 3:
+        sys.exit("Usage: %s path [cutoff_time]" % sys.argv[0])
 
     path = sys.argv[1]
 

--- a/python/upload.py
+++ b/python/upload.py
@@ -189,9 +189,8 @@ if __name__ == '__main__':
     Use from command line as: python upload.py path
     '''
 
-    if len(sys.argv) > 2:
-        print("Usage: python upload.py path")
-        raise IOError("Bad input parameters.")
+    if len(sys.argv) != 2:
+        sys.exit("Usage: %s <path>" % sys.argv[0])
 
     path = sys.argv[1]
 

--- a/python/upload_each_folder_as_sequence.py
+++ b/python/upload_each_folder_as_sequence.py
@@ -38,9 +38,9 @@ if __name__ == '__main__':
     print resp
     upload_token = resp['upload_token']
 
-    if len(sys.argv) > 3 or len(sys.argv) < 2:
-        print("Usage: python upload_each_folder_as_sequence.py path [project_name]")
-        raise IOError("Bad input parameters.")
+    if len(sys.argv) < 2 or len(sys.argv) > 3:
+        sys.exit("Usage: %s path [project_name]" % sys.argv[0])
+
     path = sys.argv[1]
 
     if path.lower().endswith(".jpg"):

--- a/python/upload_with_authentication.py
+++ b/python/upload_with_authentication.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
     '''
 
     if len(sys.argv) != 2:
-        sys.exit("Usage: python upload_with_authentication.py path" % sys.argv[0])
+        sys.exit("Usage: %s path" % sys.argv[0])
 
     path = sys.argv[1]
 

--- a/python/upload_with_authentication.py
+++ b/python/upload_with_authentication.py
@@ -97,9 +97,9 @@ if __name__ == '__main__':
     script uses pieces of that.
     '''
 
-    if len(sys.argv) > 2:
-        print("Usage: python upload_with_authentication.py path")
-        raise IOError("Bad input parameters.")
+    if len(sys.argv) != 2:
+        sys.exit("Usage: python upload_with_authentication.py path" % sys.argv[0])
+
     path = sys.argv[1]
 
     # if no success/failed folders, create them


### PR DESCRIPTION
Fixes some argv usage, tests, etc. Also better print the usage messages.
Instead things like this:

```
$ ./upload.py 
Traceback (most recent call last):
  File "./upload.py", line 196, in <module>
    path = sys.argv[1]
IndexError: list index out of range
```

We now have:

```
$ ./upload.py 
Usage: ./upload.py <path>
```

(I am asleep so I hope I didn't mess anything)
