### PR TITLE
Removal of duplicate images

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -52,6 +52,16 @@ the EXIF tag of the next image in a set of consecutive images.
 
     python interpolate_direction.py path-to-images/ [offset_angle]
 
+
+**remove_duplicates.py**
+
+Supports the work flow of an action camera, by moving images taken too close together into another folder. This is for example when waiting for a green light. Images with bad or unrealistic exif data is moved to an error folder. Run using:
+
+    python remove_duplicates.py [-d min-distance-meters] src-path/ [duplicate-path/]
+
+Run with -h to see all options. Requires either the PIL or Pillow package to be installed. Pillow is newest and is the only one which will be supported in the future. Install using pip install Pillow or see http://pillow.readthedocs.org/.
+
+
 **time_split.py**
 
 This script organizes images into sequence groups based on a cutoff time. This is useful as a step before uploading lots of photos with the manual uploader. For example:

--- a/python/lib_gps_exif.py
+++ b/python/lib_gps_exif.py
@@ -1,0 +1,193 @@
+from PIL import Image
+from PIL.ExifTags import TAGS, GPSTAGS
+import datetime
+import struct # Only to catch struct.error due to error in PIL / Pillow.
+
+# Original:  https://gist.github.com/erans/983821
+# License:   MIT
+# Credits:   https://gist.github.com/erans
+
+class ExifException(Exception):
+  def __init__(self, message):
+    self.message = message
+  def __str__(self):
+    return self.message
+
+class PILExifReader:
+  def __init__(self, filepath):
+    self.filepath = filepath
+    self.image = Image.open(filepath)
+    self.exif = self.get_exif_data(self.image)
+  def get_exif_data(self, image):
+    """Returns a dictionary from the exif data of an PIL Image item. Also converts the GPS Tags"""
+    exif_data = {}
+    try:
+      info = image._getexif()
+    except OverflowError, e:
+      if e.message == "cannot fit 'long' into an index-sized integer":
+        # Error in PIL when exif data is corrupt.
+        return None 
+      else:
+        raise e
+    except struct.error, e: 
+      if e.message == "unpack requires a string argument of length 2":
+        # Error in PIL when exif data is corrupt.
+        return None
+      else:
+        raise e
+    if info:
+      for tag, value in info.items():
+        decoded = TAGS.get(tag, tag)
+        if decoded == "GPSInfo":
+          gps_data = {}
+          for t in value:
+            sub_decoded = GPSTAGS.get(t, t)
+            gps_data[sub_decoded] = value[t]
+          exif_data[decoded] = gps_data
+        else:
+          exif_data[decoded] = value
+    return exif_data
+
+  def _get_if_exist(self, data, key):
+    if key in data:
+      return data[key]
+    else:
+      return None
+          
+  def _convert_to_degress(self, value):
+    """Helper function to convert the GPS coordinates stored in the EXIF to degrees in float format"""
+    d0 = value[0][0]
+    d1 = value[0][1]
+    d = float(d0) / float(d1)
+
+    m0 = value[1][0]
+    m1 = value[1][1]
+    m = float(m0) / float(m1)
+
+    s0 = value[2][0]
+    s1 = value[2][1]
+    s = float(s0) / float(s1)
+
+    return d + (m / 60.0) + (s / 3600.0)
+
+  def get_lat_lon(self):
+    """Returns the latitude and longitude, if available, from the provided exif_data (obtained through get_exif_data above)"""
+    lat = None
+    lon = None
+
+    gps_info = self.getGpsInfo()
+    if gps_info == None:
+      return None
+
+    gps_latitude = self._get_if_exist(gps_info, "GPSLatitude")
+    gps_latitude_ref = self._get_if_exist(gps_info, 'GPSLatitudeRef')
+    gps_longitude = self._get_if_exist(gps_info, 'GPSLongitude')
+    gps_longitude_ref = self._get_if_exist(gps_info, 'GPSLongitudeRef')
+
+    if gps_latitude and gps_latitude_ref and gps_longitude and gps_longitude_ref:
+      lat = self._convert_to_degress(gps_latitude)
+      if gps_latitude_ref != "N":                     
+        lat = 0 - lat
+
+      lon = self._convert_to_degress(gps_longitude)
+      if gps_longitude_ref != "E":
+        lon = 0 - lon
+
+    if isinstance(lat, float) and isinstance(lon, float):
+      return lat, lon
+    else:
+      return None
+      
+  def calcTuple(self, tup):
+    if tup == None or len(tup) != 2 or tup[1] == 0:
+      return None
+    return int(tup[0]) / int(tup[1])
+    
+  def getGpsInfo(self):
+    if self.exif == None or not "GPSInfo" in self.exif:
+      return None
+    else:
+      return self.exif["GPSInfo"]
+    
+  def getRotation(self):
+    """Returns the direction of the GPS receiver in degrees."""
+    gps_info = self.getGpsInfo()
+    if gps_info == None:
+      return None
+
+    gps_direction = self._get_if_exist(gps_info, "GPSTrack")
+    if gps_direction == None:
+      return None
+    if len(gps_direction) < 2 or gps_direction[1] == 0:
+      return None
+    direction = self.calcTuple(gps_direction)
+    return direction
+
+  def getSpeed(self):
+    """Returns the GPS speed in km/h or None if it does not exists."""
+    gps_info = self.getGpsInfo()
+    if gps_info == None:
+      return None
+    
+    if not "GPSSpeed" in gps_info or not "GPSSpeedRef" in gps_info:
+      return None
+    speedFrac = gps_info["GPSSpeed"]
+    speedRef = gps_info["GPSSpeedRef"]
+    
+    speed = self.calcTuple(speedFrac)
+    if speed == None or speedRef == None:
+      return None
+
+    speedRef = speedRef.lower()
+    if speedRef == "k":
+      pass # km/h - we are happy.
+    elif speedRef == "m":
+      #Miles pr. hour => km/h
+      speed *= 1.609344
+    elif speedRef == "n":
+      # Knots => km/h
+      speed *= 1.852
+    else:
+      print "Warning: Unknown format for GPS speed '%s' in '%s'." % (speedRef, self.filepath)
+      print "Please file a bug and attache the image."
+      return None
+    return speed
+
+  def isOKNum(self, val, minVal, maxVal):
+    try:
+      num = int(val)
+    except ValueError:
+      return False
+    if num < minVal or num > maxVal:
+      return False
+    return True
+
+  def getTime(self):
+    # Example data
+    # GPSTimeStamp': ((9, 1), (14, 1), (9000, 1000))
+    # 'GPSDateStamp': u'2015:05:17'
+    gps_info = self.getGpsInfo()
+    if gps_info == None:
+      return None
+    
+    if not 'GPSTimeStamp' in gps_info or not 'GPSDateStamp' in gps_info:
+      return None
+    timestamp = gps_info['GPSTimeStamp']
+    datestamp = gps_info['GPSDateStamp']
+
+    if len(timestamp) != 3:
+      raise ExifException("Timestamp does not have length 3: %s" % len(timestamp))
+    (timeH, timeM, timeS) = timestamp
+    h = self.calcTuple(timeH)
+    m = self.calcTuple(timeM)
+    s = self.calcTuple(timeS)
+    if None in (h, m, s):
+      raise ExifException("Hour, minute or second is not valid: '%s':'%s':'%s'." % (timeH, timeM, timeS))
+
+    if datestamp.count(':') != 2:
+      raise ExifException("Datestamp does not contain 2 colons: '%s'" % datestamp)
+    (y, mon, d) = [int(str) for str in datestamp.split(':')]
+    if not self.isOKNum(y, 1970, 2100) or not self.isOKNum(mon, 1, 12) or not self.isOKNum(d, 1, 31):
+      raise ExifException("Date parsed from the following is not OK: '%s'" % datestamp)
+
+    return datetime.datetime(y, mon, d, h, m, s);

--- a/python/remove_duplicates.py
+++ b/python/remove_duplicates.py
@@ -1,0 +1,351 @@
+#!/usr/bin/python
+
+import os
+import sys
+import getopt
+from math import radians, cos, sin, asin, sqrt
+from lib_gps_exif import PILExifReader
+from PIL import Image
+
+class GPSDirectionDuplicateFinder:
+  """Finds duplicates based on the direction the camera is pointing.
+  This supports the case where a panorama is being made."""
+  def __init__(self, maxDiff):
+    self.prevRotation = None
+    self.prevUniqueRotation = None
+    self.maxDiff = maxDiff
+    self.latestText = ""
+    
+  def getLatestText(self):
+    return self.latestText
+    
+  def latestIsDuplicate(self, isDuplicate):
+    if not isDuplicate:
+      self.prevUniqueRotation = self.prevRotation
+  def isDuplicate(self, filepath, exifReader):
+    rotation = exifReader.getRotation()
+
+    if rotation == None:
+      return False
+      
+    if self.prevUniqueRotation == None:
+      self.prevRotation = rotation
+      return False
+
+    diff = abs(rotation - self.prevUniqueRotation)
+    isDuplicate = diff < self.maxDiff
+
+    self.prevRotation = rotation
+    self.latestText = str(int(diff))+" deg: "+str(isDuplicate)
+    return isDuplicate
+
+class GPSDistance:
+  """Calculates the distance between two sets of GPS coordinates."""
+  @staticmethod
+  def getGPSDistance(lat1, lon1, lat2, lon2):
+    """
+    Calculate the great circle distance between two points 
+    on the earth (specified in decimal degrees with a result in meters).
+      
+    This is done using the Haversine Formula.
+    """
+    # Convert decimal degrees to radians 
+    lat1, lon1, lat2, lon2 = map(radians, [lat1, lon1, lat2, lon2])
+
+    # Haversine formula
+    difflat = lat2 - lat1
+    difflon = lon2 - lon1
+    a = (sin(difflat / 2) ** 2) + (cos(lat1) * cos(lat2) * sin(difflon / 2) ** 2)
+    difflon = lon2 - lon1 
+    c = 2 * asin(sqrt(a)) 
+    r = 6371000 # Radius of The Earth in meters.
+                # It is not a perfect sphere, so this is just good enough.
+    return c * r
+
+class GPSSpeedErrorFinder:
+  """Finds images in a sequence that might have an error in GPS data
+     or suggest a track to be split. It is done by looking at the
+     speed it would take to travel the distance in question."""
+  def __init__(self, maxSpeedKmH, wayTooHighSpeedKmH):
+    self.prevLatLon = None
+    self.previous = None
+    self.latestText = ""
+    self.previousFilepath = None
+    self.maxSpeedKmH = maxSpeedKmH
+    self.wayTooHighSpeedKmH = wayTooHighSpeedKmH
+    self.highSpeed = False
+    self.tooHighSpeed = False
+    
+  def setVerbose(self, verbose):
+    self.verbose = verbose
+  def getLatestText(self):
+    return self.latestText
+  def isError(self, filepath, exifReader):
+    """
+    Returns if there is an obvious error in the images exif data.
+    The given image is an instance of PIL's Image class.
+    the given exif is the data from the get_exif_data function.
+    """
+    speedGPS = exifReader.getSpeed()
+    if speedGPS == None:
+      self.latestText = "None or corrupt exif data."
+      return True
+    self.latestText = "Speed GPS: "+str(speedGPS)+" km/h"
+    if speedGPS > self.wayTooHighSpeedKmH:
+      self.latestText = "GPS speed is unrealistically high: %s km/h."
+      self.tooHighSpeed = True
+      return True
+    elif speedGPS > self.maxSpeedKmH:
+      self.latestText = "GPS speed is high: %s km/h."
+      self.highSpeed = True
+      return True
+
+    latlong = exifReader.get_lat_lon()
+    timestamp = exifReader.getTime()
+
+    if self.prevLatLon == None or self.prevTime == None:
+      self.prevLatLon = latlong
+      self.prevTime = timestamp
+      self.previousFilepath = filepath
+      return False
+      
+    if latlong == None or timestamp == None:
+      return False
+    diffMeters = GPSDistance.getGPSDistance(self.prevLatLon[0], self.prevLatLon[1], latlong[0], latlong[1])
+    diffSecs = (timestamp - self.prevTime).total_seconds()
+
+    if diffSecs == 0:
+      return False
+    speedKmH = (diffMeters / diffSecs) * 3.6
+    
+    if speedKmH > self.wayTooHighSpeedKmH:
+      self.latestText = "Speed between %s and %s is %s km/h, which is unrealistically high." % (self.previousFilepath, filepath, int(speedKmH))
+      self.tooHighSpeed = True
+      return True
+    elif speedKmH > self.maxSpeedKmH:
+      self.latestText = "Speed between %s and %s is %s km/h." % (self.previousFilepath, filepath, int(speedKmH))
+      self.highSpeed = True
+      return True
+    else:
+      return False
+
+class GPSDistanceDuplicateFinder:
+  """Finds duplicates images by looking at the distance between two GPS points."""
+  def __init__(self, distance):
+    self.distance = distance
+    self.prevLatLon = None
+    self.previous = None
+    self.latestText = ""
+    self.previousFilepath = None
+    self.prevUniqueLatLon = None
+    
+  def getLatestText(self):
+    return self.latestText
+  def latestIsDuplicate(self, isDuplicate):
+    if not isDuplicate:
+      self.prevUniqueLatLon = self.prevLatLon
+  def isDuplicate(self, filepath, exifReader):
+    """
+    Returns if the given image is a duplicate of the previous image.
+    The given image is an instance of PIL's Image class.
+    the given exif is the data from the get_exif_data function.
+    """
+    latlong = exifReader.get_lat_lon()
+    
+    if self.prevLatLon == None:
+      self.prevLatLon = latlong
+      return False
+
+    if self.prevUniqueLatLon != None and latlong != None:
+      diffMeters = GPSDistance.getGPSDistance(
+              self.prevUniqueLatLon[0], self.prevUniqueLatLon[1], latlong[0], latlong[1])
+      self.previousFilepath = filepath
+      isDuplicate = diffMeters <= self.distance
+      self.prevLatLon = latlong
+      self.latestText = str(int(diffMeters)) + " m: "+str(isDuplicate)
+      return isDuplicate
+    else:
+      return False
+
+class ImageRemover:
+  """Moves images that are (almost) duplicates or contains errors in GPS data into
+  separate directories."""
+  def __init__(self, srcDir, duplicateDir, errorDir):
+    self.testers = []
+    self.errorFinders = []
+    self.srcDir = srcDir
+    self.duplicateDir = duplicateDir
+    self.errorDir = errorDir
+    self.dryrun = False
+    self.verbose = 0
+  def setVerbose(self, verbose):
+    self.verbose = verbose
+  def setDryRun(self, dryrun):
+    self.dryrun = dryrun
+  def addDuplicateFinder(self, tester):
+    self.testers.append(tester)
+  def addErrorFinder(self, finder):
+    self.errorFinders.append(finder)
+  def moveIntoErrorDir(self, file):
+    self.moveIntoDir(file, self.errorDir)
+  def moveIntoDuplicateDir(self, file):
+    self.moveIntoDir(file, self.duplicateDir)
+  def moveIntoDir(self, file, dir):
+    if not self.dryrun and not os.path.exists(dir):
+      os.makedirs(dir)
+    filename = os.path.basename(file)
+    if not self.dryrun:
+      os.rename(file, os.path.join(dir, filename))
+    print file, " => ", dir
+       
+  def doMagic(self):
+    """Perform the task of finding and moving images."""
+    files = [f for f in os.listdir(self.srcDir) if os.path.isfile(self.srcDir+'/'+f) and f.lower().endswith('.jpg')]
+    list.sort(files)
+    
+    for file in files:
+      filepath = os.path.join(self.srcDir, file)
+      exifReader = PILExifReader(filepath)
+      isError = self.handlePossibleError(filepath, exifReader)
+      if not isError:
+        self.handlePossibleDuplicate(filepath, exifReader)
+      
+  def handlePossibleDuplicate(self, filepath, exifReader):
+    isDuplicate = True
+    verboseText = []
+    for tester in self.testers:
+      isDuplicate &= tester.isDuplicate(filepath, exifReader)
+      verboseText.append(tester.getLatestText())
+
+    if self.verbose >= 1:
+      print ", ".join(verboseText), "=>", isDuplicate
+    if isDuplicate:
+      self.moveIntoDuplicateDir(filepath)
+    for tester in self.testers:
+      tester.latestIsDuplicate(isDuplicate)
+    return isDuplicate
+
+  def handlePossibleError(self, filepath, exifReader):
+    isError = False
+    for finder in self.errorFinders:
+      err = finder.isError(file, exifReader)
+      if err:
+        print finder.getLatestText()
+      isError |= err
+    if isError:
+      self.moveIntoErrorDir(filepath)
+    return isError
+    
+if __name__ == "__main__":
+  distance = 4
+  pan = 20
+  errorDir = "errors"
+  fastKmH = 150
+  tooFastKmH = 200
+  def printHelp():
+    print """Usage: remove-duplicates.py [-h | -d] srcDir duplicateDir
+    Finds images in srcDir and moves duplicates to duplicateDir.
+    
+    Both srcDir and duplicateDir are mandatory. If srcDir is not .
+    and duplicateDir is not given, it will be named "duplicate" and put
+    in the current directory.
+    If duplicateDir does not exist, it will be created in the current
+    directory (no matter if it will be used or not).
+
+    In order to be considered a duplicate, the image must match ALL criteria
+    to be a duplicate. With default settings that is, it must have travelled
+    less than """+str(distance)+"""  meters and be panned less than """+str(pan)+""" degrees.
+    This supports that you ride straight ahead with a significant speed,
+    that you make panoramas standing still and standing still waiting for
+    the red light to change into green.    
+
+    Important: The upload.py from Mapillary uploads *recursively* so do not
+    put the duplicateDir under the dir your are uploading from!
+    
+    Options:
+    -e --error-dir Give the directory to put pictures into, if they contains obvious errors.
+                   Default value is """ +errorDir+ """
+    -h --help      Print this message and exit.
+    -d --distance  Give the maximum distance in meters images must be taken
+                   not to be considered duplicates. Default is """+str(distance)+""" meters.
+                   The distance is calculated from embedded GPS data. If there
+                   is no GPS data the images are ignored.
+    -a --fast      The speed (km/h) which is a bit too fast. E.g. 40 for a bicycle.
+                   Default value is: """ +str(fastKmH)+ """ km/h
+    -t --too-fast  The speed (km/h) which is way too fast. E.g. 70 for a bicycle.
+                   Default value is: """ +str(tooFastKmH)+ """ km/h
+    -p --pan       The maximum distance in degrees (0-360) the image must be
+                   panned in order not to be considered a duplicate.
+                   Default is """+str(pan)+""" degrees.
+    -n --dry-run   Do not move any files. Just simulate.
+    -v --verbose   Print extra info.
+    """
+    
+  dryrun = False
+  verbose = 0
+  try:
+      opts, args = getopt.getopt(sys.argv[1:], "hd:p:nve:",
+                    ["help", "distance=", "pan=", "dry-run", "verbose", "error-dir"])
+  except getopt.GetoptError, err:
+    print str(err)
+    sys.exit(2)
+  for switch, value in opts:
+    if switch in ("-h", "--help"):
+      printHelp()
+      sys.exit(0)
+    elif switch in ("-d", "--distance"):
+      distance = float(value)
+    elif switch in ("-p", "--pan"):
+      pan = float(value)
+    elif switch in ("-n", "--dry-run"):
+      dryrun = True
+    elif switch in ("-v", "--verbose"):
+      verbose += 1
+    elif switch in ("-e", "--error-dir"):
+      errorDir = value
+    
+  if len(args) == 1 and args[0] != ".":
+    duplicateDir = "duplicates"
+  elif len(args) < 2:
+    printHelp()
+    sys.exit(2)
+  else:
+    duplicateDir = args[1]
+
+  srcDir = args[0]
+
+  distanceFinder = GPSDistanceDuplicateFinder(distance)
+  directionFinder = GPSDirectionDuplicateFinder(pan)
+  speedErrorFinder = GPSSpeedErrorFinder(fastKmH, tooFastKmH)
+  
+  imageRemover = ImageRemover(srcDir, duplicateDir, errorDir)
+  imageRemover.setDryRun(dryrun)
+  imageRemover.setVerbose(verbose)
+  
+  # Modular: Multiple testers can be added.
+  imageRemover.addDuplicateFinder(distanceFinder)
+  imageRemover.addDuplicateFinder(directionFinder)
+  imageRemover.addErrorFinder(speedErrorFinder)
+
+  try:
+    imageRemover.doMagic()
+  except KeyboardInterrupt:
+    print "You cancelled."
+    sys.exit(1)
+  if False:
+    showSplit = False
+    if False and distanceFinder.isLongDistanceBetween():
+      showSplit = True
+      print
+      print "Some of your images have a long distance between them."
+      print "Strongly consider splitting them into multiple series."
+    if False and distanceFinder.isTooLongDistanceBetween():
+      showSplit = True
+      print 
+      print "Some of your images have way too long a distance between them to be ok."
+      print "Mabye your GPS started out with a wrong location or you traveled between sets?"
+    if showSplit:
+      print
+      print "See http://blog.mapillary.com/update/2014/06/16/actioncam-workflow.html on how"
+      print "to use time_split.py to automatically split a lot of images into multiple series."
+


### PR DESCRIPTION
I mostly map using an action cam, that takes an image e.g. once each second. When crossing streets I need to remove a lot of images and when going slow once a second produces too many images. Further more the cameras GPS has manged to put my first images in Russia, when I was in Denmark, creating some very long lines on the world map (thanks to Peter Neubauer for pointing it out).

This caused me to write this script:
* Images too close are moved to a duplicate folder. Parameters for distance and panning can be given.
* Images with unrealistic high speeds are moved to an error folder. Speed is both taken from EXIF and calculated between images. It also suggests if time_split.py should be run.

The script uses PIL/Pillow instead of exif_read, like the other scripts. The reason is, that exif_read is easily 10 times slower than PIL.

The script uses the main script and a library, lib_gps_exif.py, which handles the exif stuff. The latter is based on code from Stackoverflow, which the author in a thread had commented, was released under the MIT license. Credit is given in the code. Everything is made as reuseable classes and the main script has a design that makes it easy to add other classes that finds duplicates or errors.

I will gladly maintain the script in the future as my time with one (soon two) kids allows :-)