### PR TITLE
Bugfixes and sorting

### DIFF
--- a/python/lib_gps_exif.py
+++ b/python/lib_gps_exif.py
@@ -19,8 +19,9 @@ class ExifException(Exception):
 class PILExifReader:
     def __init__(self, filepath):
         self._filepath = filepath
-        self._image = Image.open(filepath)
-        self._exif = self.get_exif_data(self._image)
+        image = Image.open(filepath)
+        self._exif = self.get_exif_data(image)
+        image.close()
 
     def get_exif_data(self, image):
         """Returns a dictionary from the exif data of an PIL Image

--- a/python/lib_gps_exif.py
+++ b/python/lib_gps_exif.py
@@ -53,6 +53,21 @@ class PILExifReader:
                     exif_data[decoded] = value
         return exif_data
 
+    def read_capture_time(self):
+        time_tag = "DateTimeOriginal"
+
+        # read and format capture time
+        if time_tag in self._exif:
+            capture_time = self._exif[time_tag]
+            capture_time = capture_time.replace(" ","_")
+            capture_time = capture_time.replace(":","_")
+        else:
+            print self._exif
+            capture_time = 0
+
+        # return as datetime object
+        return datetime.datetime.strptime(capture_time, '%Y_%m_%d_%H_%M_%S')
+
     def _get_if_exist(self, data, key):
         if key in data:
             return data[key]

--- a/python/remove_duplicates.py
+++ b/python/remove_duplicates.py
@@ -41,7 +41,7 @@ class GPSDirectionDuplicateFinder:
         is_duplicate = diff < self._max_diff
 
         self._prev_rotation = rotation
-        self._latest_text = str(int(diff)) + " deg: " + str(is_duplicate)
+        self._latest_text = str(int(diff)) + " deg: " + str(is_duplicate) + "(%s -  %s)" % (rotation, self._prev_unique_rotation)
         return is_duplicate
 
 
@@ -376,6 +376,7 @@ if __name__ == "__main__":
     if len(args) == 1 and args[0] != ".":
         duplicate_dir = "duplicates"
     elif len(args) < 2:
+        print "Only got %s arguments" % len(args)
         print_help()
         sys.exit(2)
     else:

--- a/python/remove_duplicates.py
+++ b/python/remove_duplicates.py
@@ -204,11 +204,7 @@ class ImageRemover:
         self._duplicate_dir = duplicate_dir
         self._error_dir = error_dir
         self._dryrun = False
-        self._min_duplicates = 3
         self.verbose = 0
-
-    def set_min_duplicates(self, min_duplicates):
-        self._min_duplicates = min_duplicates
 
     def set_verbose(self, verbose):
         self.verbose = verbose
@@ -361,8 +357,6 @@ if __name__ == "__main__":
             verbose += 1
         elif switch in ("-e", "--error-dir"):
             error_dir = value
-        elif switch in ("-m", "--min-dup"):
-            min_duplicates = int(value)
 
     if len(args) == 1 and args[0] != ".":
         duplicate_dir = "duplicates"
@@ -381,7 +375,6 @@ if __name__ == "__main__":
     image_remover = ImageRemover(src_dir, duplicate_dir, error_dir)
     image_remover.set_dry_run(dryrun)
     image_remover.set_verbose(verbose)
-    image_remover.set_min_duplicates(min_duplicates)
 
     # Modular: Multiple testers can be added.
     image_remover.add_duplicate_finder(distance_finder)
@@ -393,23 +386,3 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         print "You cancelled."
         sys.exit(1)
-    if False:  # TODO Finish.
-        show_split = False
-        if distance_finder.isLongDistanceBetween():
-            show_split = True
-            print
-            print "Some of your images have a long distance between them."
-            print "Strongly consider splitting them into multiple series."
-        if distance_finder.isTooLongDistanceBetween():
-            show_split = True
-            print
-            print "Some of your images have way too long a distance "
-            + "between them to be ok."
-            print "Mabye your GPS started out with a wrong location "
-            + "or you traveled between sets?"
-        if show_split:
-            print
-            print "See http://blog.mapillary.com/update/2014/06/16/actioncam-workflow.html"
-            + "on how"
-            print "to use time_split.py to automatically split a lot "
-            + "of images into multiple series."


### PR DESCRIPTION
New
* Images are now sorted by creation time as e.g. time_split.

Bugfix
* Images without a proper orientation tag can now be duplicates too.
* Image resources are closed properly.

Note
Sorting by creation time is done at least 20-30 times faster by this script than the same operation is done by e.g. time_split.py. The reason is that this script uses PIL/Pillow which is much faster than exif_read.
In lib_gps_exif.py, in the class PILExifReader now have the method read_capture_time which works exactly like its counterpart in time_split.py, except that it is much much faster.
See remove_duplicates.pyline 243 for a 3 line example on how it can be used.
The only issue with this method is that some times PIL or Pillow is harder to install. PIL is the original Python image library but is not maintained. Pillow can replace PIL without any chagnes and is maintained.