### PR TITLE
Fix defects regarding EXIF tags

### DIFF
--- a/python/lib_gps_exif.py
+++ b/python/lib_gps_exif.py
@@ -58,6 +58,8 @@ class PILExifReader:
         time_tag = "DateTimeOriginal"
 
         # read and format capture time
+        if self._exif == None:
+            print "Exif is none."
         if time_tag in self._exif:
             capture_time = self._exif[time_tag]
             capture_time = capture_time.replace(" ","_")
@@ -139,13 +141,14 @@ class PILExifReader:
         if gps_info is None:
             return None
 
-        gps_direction = self._get_if_exist(gps_info, "GPSTrack")
-        if gps_direction is None:
-            return None
-        if len(gps_direction) < 2 or gps_direction[1] == 0:
-            return None
-        direction = self.calc_tuple(gps_direction)
-        return direction
+        for tag in ('GPSTrack', 'DSC07558.JPG'):
+            gps_direction = self._get_if_exist(gps_info, tag)
+            direction = self.calc_tuple(gps_direction)
+            if direction == None:
+                continue
+            else:
+                return direction
+        return None
 
     def get_speed(self):
         """Returns the GPS speed in km/h or None if it does not exists."""

--- a/python/remove_duplicates.py
+++ b/python/remove_duplicates.py
@@ -100,8 +100,8 @@ class GPSSpeedErrorFinder:
     """
         speed_gps = exif_reader.get_speed()
         if speed_gps is None:
-            self._latest_text = "None or corrupt exif data."
-            return True
+            self._latest_text = "No speed given in EXIF data."
+            return False
         self._latest_text = "Speed GPS: " + str(speed_gps) + " km/h"
         if speed_gps > self._way_too_high_speed_km_h:
             self._latest_text = ("GPS speed is unrealistically high: %s km/h."


### PR DESCRIPTION
This PR fixes two defects:
1. Missing GPS Speed tag is now handled correctly. Fixes #70 .
2. GPS Img Direction is now preferred over GPS Track for orientation (the first is measured by compass, the latter is calculated from the track) and both can be missing.