### PR TITLE
Don't fail if gpxpy isn't needed and can't be loaded

### DIFF
--- a/python/geotag_from_gpx.py
+++ b/python/geotag_from_gpx.py
@@ -2,7 +2,6 @@
 
 import sys
 import os
-import gpxpy
 import datetime
 import pyexiv2
 import math
@@ -10,6 +9,10 @@ import time
 from pyexiv2.utils import make_fraction
 from dateutil.tz import tzlocal
 
+try:
+    import gpxpy
+except ImportError:
+    print("gpxpy not found, running unable to read GPX tracks")
 '''
 Script for geotagging images using a gpx file from an external GPS.
 Intended as a lightweight tool.


### PR DESCRIPTION
gpxpy isn't commonly packaged, and is only used by one function. Before, it was needed to run interpolate_direction.py even though it wasn't used by it