### PR TITLE
Changed shebang to /usr/bin/env

### DIFF
--- a/python/add_fix_dates.py
+++ b/python/add_fix_dates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os

--- a/python/add_mapillary_tag_from_exif.py
+++ b/python/add_mapillary_tag_from_exif.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import division
 import sys

--- a/python/add_project.py
+++ b/python/add_project.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import pyexiv2
 import sys
 import os

--- a/python/download_images.py
+++ b/python/download_images.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import sys
 import urllib2, urllib
 import json

--- a/python/geotag_from_gpx.py
+++ b/python/geotag_from_gpx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os

--- a/python/interpolate_direction.py
+++ b/python/interpolate_direction.py
@@ -1,4 +1,4 @@
- #!/usr/bin/python
+#!/usr/bin/env python
 
 import os, sys, pyexiv2
 

--- a/python/remove_duplicates.py
+++ b/python/remove_duplicates.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import getopt
 import os

--- a/python/time_split.py
+++ b/python/time_split.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os

--- a/python/upload.py
+++ b/python/upload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import urllib2, urllib

--- a/python/upload_with_authentication.py
+++ b/python/upload_with_authentication.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import urllib2, urllib


### PR DESCRIPTION
If python is located at a different place on the file system or a user is using not the standard python (which is done often on OS X), it is much more convenient to use `/usr/bin/env python`, which will automatically select the right one.
