### PR TITLE
Fix import error for dateutil.tz

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
 gpxpy
 exifread
 Pillow
+python-dateutil


### PR DESCRIPTION
Fix following error for me:

```
Traceback (most recent call last):
  File "mapillary_tools/python/geotag_from_gpx.py", line 11, in <module>
    from dateutil.tz import tzlocal
ImportError: No module named dateutil.tz
```