### PR TITLE
Also print response body for HTTP Errors

### DIFF
--- a/python/upload.py
+++ b/python/upload.py
@@ -33,8 +33,8 @@ MAPILLARY_UPLOAD_URL = "https://d22zcsn13kp53w.cloudfront.net/"
 PERMISSION_HASH = "eyJleHBpcmF0aW9uIjoiMjAyMC0wMS0wMVQwMDowMDowMFoiLCJjb25kaXRpb25zIjpbeyJidWNrZXQiOiJtYXBpbGxhcnkudXBsb2Fkcy5pbWFnZXMifSxbInN0YXJ0cy13aXRoIiwiJGtleSIsIiJdLHsiYWNsIjoicHJpdmF0ZSJ9LFsic3RhcnRzLXdpdGgiLCIkQ29udGVudC1UeXBlIiwiIl0sWyJjb250ZW50LWxlbmd0aC1yYW5nZSIsMCwxMDQ4NTc2MF1dfQ=="
 SIGNATURE_HASH = "foNqRicU/vySm8/qU82kGESiQhY="
 BOUNDARY_CHARS = string.digits + string.ascii_letters
-NUMBER_THREADS = 1
-MAX_ATTEMPTS = 10
+NUMBER_THREADS = 4
+MAX_ATTEMPTS = 4
 UPLOAD_PARAMS = {"url": MAPILLARY_UPLOAD_URL, "permission": PERMISSION_HASH, "signature": SIGNATURE_HASH, "move_files":True}
 
 

--- a/python/upload.py
+++ b/python/upload.py
@@ -33,8 +33,8 @@ MAPILLARY_UPLOAD_URL = "https://d22zcsn13kp53w.cloudfront.net/"
 PERMISSION_HASH = "eyJleHBpcmF0aW9uIjoiMjAyMC0wMS0wMVQwMDowMDowMFoiLCJjb25kaXRpb25zIjpbeyJidWNrZXQiOiJtYXBpbGxhcnkudXBsb2Fkcy5pbWFnZXMifSxbInN0YXJ0cy13aXRoIiwiJGtleSIsIiJdLHsiYWNsIjoicHJpdmF0ZSJ9LFsic3RhcnRzLXdpdGgiLCIkQ29udGVudC1UeXBlIiwiIl0sWyJjb250ZW50LWxlbmd0aC1yYW5nZSIsMCwxMDQ4NTc2MF1dfQ=="
 SIGNATURE_HASH = "foNqRicU/vySm8/qU82kGESiQhY="
 BOUNDARY_CHARS = string.digits + string.ascii_letters
-NUMBER_THREADS = 4
-MAX_ATTEMPTS = 4
+NUMBER_THREADS = 1
+MAX_ATTEMPTS = 10
 UPLOAD_PARAMS = {"url": MAPILLARY_UPLOAD_URL, "permission": PERMISSION_HASH, "signature": SIGNATURE_HASH, "move_files":True}
 
 
@@ -130,7 +130,7 @@ def upload_file(filepath, url, permission, signature, key=None, move_files=True)
                 break # attempts
 
             except urllib2.HTTPError as e:
-                print("HTTP error: {0} on {1}".format(e, filename))
+                print("HTTP error: {0} on {1}: '{2}'.".format(e, filename, e.read()))
             except urllib2.URLError as e:
                 print("URL error: {0} on {1}".format(e, filename))
             except socket.timeout as e:

--- a/python/upload_with_authentication.py
+++ b/python/upload_with_authentication.py
@@ -40,7 +40,7 @@ USE UPLOAD.PY INSTEAD.
 
 
 MAPILLARY_UPLOAD_URL = "https://s3-eu-west-1.amazonaws.com/mapillary.uploads.manual.images"
-NUMBER_THREADS = 4
+NUMBER_THREADS = 1
 MOVE_FILES = False
 
 
@@ -172,6 +172,10 @@ if __name__ == '__main__':
     print("===\nFinalizing upload will submit all successful uploads and ignore all failed.\nIf all files were marked as successful, everything is fine, just press 'y'.")
 
     # ask 3 times if input is unclear
+    upload_done_file(params)
+    print("Done uploading.")
+    sys.exit()
+
     for i in range(3):
         proceed = raw_input("Finalize upload? [y/n]: ")
         if proceed in ["y", "Y", "yes", "Yes"]:


### PR DESCRIPTION
Amazon gives the same http error codes for many different errors. To debug one (and make a bug report) I had to print the http body when I get an HTTPError. This change will allow more people to give detailed bug reports.