### PR TITLE
Remove unnecessary matplotlib dependency.

### DIFF
--- a/python/geotag_from_gpx.py
+++ b/python/geotag_from_gpx.py
@@ -9,7 +9,6 @@ import math
 import time
 from pyexiv2.utils import make_fraction
 from dateutil.tz import tzlocal
-import matplotlib.pyplot as plt
 from lib.geo import interpolate_lat_lon, decimal_to_dms, utc_to_localtime
 
 '''

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,4 +2,3 @@ gpxpy
 exifread
 Pillow==2.9.0
 python-dateutil
-matplotlib


### PR DESCRIPTION
It wasn't being used anywhere in the code. In addition, matplotlib depends
on numpy, which has native-code parts, and was making pip tell Windows
users to install Visual C++.