### PR TITLE
Make file ordering explicit

### DIFF
--- a/python/geotag_from_gpx.py
+++ b/python/geotag_from_gpx.py
@@ -170,6 +170,7 @@ if __name__ == '__main__':
         # folder(s)
         file_list = []
         for root, sub_folders, files in os.walk(args.path):
+            files.sort()
             file_list += [os.path.join(root, filename) for filename in files if filename.lower().endswith(".jpg")]
 
     # start time


### PR DESCRIPTION
The list coming from os.walk is in an arbitrary order but the sub-second timing function needs the list of files to be ordered.

I kept getting the ```Interval not compatible with EXIF times``` error message on a sequence that seemed like it should be working. It turns out ```smin``` and ```smax``` in the sub-second timing function were being initialized from some random picture in the middle of the sequence and things went crazy from there.

This does rely on file name sorting and assumes this matches the order in which the photos were taken but I feel like for action cameras this is a pretty safe bet.