### PR TITLE
Workaround for BadStatusLine error

### DIFF
--- a/python/lib/uploader.py
+++ b/python/lib/uploader.py
@@ -5,7 +5,7 @@ import os
 import string
 import threading
 import sys
-import urllib2, urllib
+import urllib2, urllib, httplib
 import socket
 import mimetypes
 import random
@@ -216,6 +216,9 @@ def upload_file(filepath, url, permission, signature, key=None, move_files=True,
             time.sleep(5)
         except urllib2.URLError as e:
             print("URL error: {0} on {1}".format(e, filename))
+            time.sleep(5)
+        except httplib.HTTPException as e:
+            print("HTTP exception: {0} on {1}".format(e, filename))
             time.sleep(5)
         except OSError as e:
             print("OS error: {0} on {1}".format(e, filename))


### PR DESCRIPTION
Workaround for https://github.com/mapillary/mapillary_tools/issues/113. Catch HTTPException due to which BadStatusLine error shows up. This way the thread where the exception appears is not interrupted and the file upload can be retried again until MAX_ATTEMPTS is reached. Don't know why the HTTPException is raised in the first place, but this way the sequence upload can be finished.
