### PR TITLE
Add offset_angle parameter for upload_with_preprocessing.py

### DIFF
--- a/python/lib/exifedit.py
+++ b/python/lib/exifedit.py
@@ -12,6 +12,7 @@ from lib.exif import EXIF, verify_exif
 def create_mapillary_description(filename, username, email,
                                  upload_hash, sequence_uuid,
                                  interpolated_heading=None,
+                                 offset_angle=0.0,
                                  orientation=1,
                                  verbose=False):
     '''
@@ -34,7 +35,7 @@ def create_mapillary_description(filename, username, email,
     heading = exif.extract_direction()
     if heading is None:
         heading = 0.0
-    heading = normalize_bearing(interpolated_heading) if interpolated_heading is not None else normalize_bearing(heading)
+    heading = normalize_bearing(interpolated_heading + offset_angle) if interpolated_heading is not None else normalize_bearing(heading + offset_angle)
     mapillary_description["MAPCompassHeading"] = {"TrueHeading": heading, "MagneticHeading": heading}
     mapillary_description["MAPSettingsUploadHash"] = upload_hash
     mapillary_description["MAPSettingsEmail"] = email

--- a/python/upload_with_preprocessing.py
+++ b/python/upload_with_preprocessing.py
@@ -98,6 +98,7 @@ if __name__ == '__main__':
     parser.add_argument('--remove_duplicates', help='perform duplicate removal', action='store_true')
     parser.add_argument('--rerun', help='rerun the preprocessing and uploading', action='store_true')
     parser.add_argument('--interpolate_directions', help='perform interploation of directions', action='store_true')
+    parser.add_argument('--offset_angle', help='offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing)', default=0)
     parser.add_argument('--skip_upload', help='skip uploading to server', action='store_true')
     parser.add_argument('--duplicate_distance', help='max distance for two images to be considered duplicates in meters', default=0.1)
     parser.add_argument('--duplicate_angle', help='max angle for two images to be considered duplicates in degrees', default=5)
@@ -108,6 +109,7 @@ if __name__ == '__main__':
     cutoff_distance = float(args.cutoff_distance)
     cutoff_time = float(args.cutoff_time)
     skip_upload = args.skip_upload
+    offset_angle = float(args.offset_angle)
     interpolate_directions = args.interpolate_directions
     orientation = int(args.orientation)
     auto_done = args.auto_done
@@ -217,6 +219,7 @@ if __name__ == '__main__':
                                                              upload_token,
                                                              sequence_uuid,
                                                              bearing,
+                                                             offset_angle,
                                                              orientation)
                             file_list.append(filepath)
                         else:


### PR DESCRIPTION
re #127 

This lets the bulk uploader accept an `offset_angle` parameter for side/rear-facing cameras.

I'm still seeing some mysterious orientation flips though, so not sure if there is something broken in the `normalize_bearing` code.

Supposed to be rear-facing:
<img width="619" alt="screenshot 2016-08-18 09 47 25" src="https://cloud.githubusercontent.com/assets/38784/17777271/f00559cc-652d-11e6-966f-44be52dc0127.png">

Supposed to be right-facing:
<img width="744" alt="screenshot 2016-08-18 09 53 31" src="https://cloud.githubusercontent.com/assets/38784/17777268/ef9a95ba-652d-11e6-8248-c1b4ec5910f1.png">
