### PR TITLE
Allow time_offset to be specified in floating point seconds

### DIFF
--- a/python/add_fix_dates.py
+++ b/python/add_fix_dates.py
@@ -11,10 +11,10 @@ from pyexiv2.utils import make_fraction
 
 '''
 Script for adding dates to jpg files extracted from video with no tags. if you have a directory of files
-provide the directory, the datetime for the first file, and an increment in seconds. Ie if the photos are 
-taken every 2 seconds 
+provide the directory, the datetime for the first file, and an increment in seconds. Ie if the photos are
+taken every 2 seconds
 python add_fix_dates.py /home/me/myphotos/ '2014-11-27 13:01:01' 2
-You can use local time, that is expected. Maybe GMT if i get to it. 
+You can use local time, that is expected. Maybe GMT if i get to it.
 
 !!! This version needs testing, please report issues.!!!
 
@@ -32,7 +32,7 @@ def add_exif_using_timestamp(filename, start_time, offset_time):
     metadata.read()
     t = start_time + datetime.timedelta(seconds=offset_time)
     print("setting {0} time to {1} due to offset {2}".format(filename, t, offset_time))
-	
+
     try:
        metadata["Exif.Photo.DateTimeOriginal"] = t;
        metadata.write()
@@ -46,8 +46,8 @@ if __name__ == '__main__':
     '''
     Use from command line as: python add_fix_dates.py images-path StartTime increment-in-seconds
     if you provide a start time and increment, the first photo will be tagged at start time, and
-    each subsequent photo will be tagged with prior photo + increment seconds. 
- 
+    each subsequent photo will be tagged with prior photo + increment seconds.
+
     '''
 
     if len(sys.argv) != 4:
@@ -55,9 +55,9 @@ if __name__ == '__main__':
         raise IOError("Bad input parameters.")
     path = sys.argv[1]
     start_time = sys.argv[2]
-    time_offset = int(sys.argv[3])
+    time_offset = float(sys.argv[3])
     #print("time offset is {0}".format(time_offset))
-    
+
     if path.lower().endswith(".jpg"):
         # single file
         file_list = [path]
@@ -72,7 +72,7 @@ if __name__ == '__main__':
     start_time_dt = datetime.datetime.strptime(start_time,'%Y-%m-%d %H:%M:%S');
 
     for filepath in file_list:
-            add_exif_using_timestamp(filepath, start_time_dt, inc) 
-            inc = inc + time_offset    
+            add_exif_using_timestamp(filepath, start_time_dt, inc)
+            inc = inc + time_offset
 
-   
+


### PR DESCRIPTION
This allows `time_offset` in `add_fix_dates.py` to be provided in floating point rather than integer seconds.   (for example, in case you are extracting from a timelapse sequence with frames at half second intervals.)