### PR TITLE
Support for projects with whitespace in the name in video upload

### DIFF
--- a/python/upload_video_with_preprocessing.py
+++ b/python/upload_video_with_preprocessing.py
@@ -45,6 +45,6 @@ if __name__ == "__main__":
             "--duplicate_angle", "360",
             "--user", args.user,
             "--email", args.email,
-            "--project", args.project
+            "--project", repr(args.project)
         ]
         run(upload_cmd)


### PR DESCRIPTION
The way the command is built and executed in `upload_video_with_preprocessing.py` results in an error when project name contains whitespace. The solution is to add quotes to project name.