### PR TITLE
Ignore video metadata in incorrect format

### DIFF
--- a/python/lib/ffprobe.py
+++ b/python/lib/ffprobe.py
@@ -80,9 +80,12 @@ class FFStream:
     """
     def __init__(self,datalines):
         for a in datalines:
-            (key,val)=a.strip().split('=')
-            key = key.lstrip("TAG:")
-            self.__dict__[key]=val
+            if re.match(r'^.+=.+$', a) is None:
+                print "Warning: detected incorrect stream metadata line format: %s" % a
+            else:
+                (key,val)=a.strip().split('=')
+                key = key.lstrip("TAG:")
+                self.__dict__[key]=val
 
     def isAudio(self):
         """


### PR DESCRIPTION
The video metadata parsing in `ffprobe.py` assumes the lines returned from `ffprobe -show_streams` are always in the format of `key=value`. However for some videos, this may not be true. As a result, the script crashes.

Here's a sample output from video captured with Garmin VIRB XE:

```
[STREAM]
index=0
codec_name=h264
codec_long_name=H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
...more properties here...
TAG:language=eng
TAG:handler_name=
Garmin AVC
TAG:encoder=Garmin AVC encoder
[/STREAM]
```

The `TAG:handler_name` property value starts with newline for some reason.

Te solution suggested in this PR is to ignore the lines in incorrect format (but print a warning).