### PR TITLE
remove_duplicates: Fix move between different devices #154

### DIFF
--- a/python/remove_duplicates.py
+++ b/python/remove_duplicates.py
@@ -3,6 +3,7 @@
 import getopt
 import os
 import sys
+import shutil
 from math import asin, cos, radians, sin, sqrt
 
 from PIL import Image
@@ -237,7 +238,7 @@ class ImageRemover:
             os.makedirs(dir)
         filename = os.path.basename(file)
         if not self._dryrun:
-            os.rename(file, os.path.join(dir, filename))
+            shutil.move(file, os.path.join(dir, filename))
         print file, " => ", dir
 
     def _read_capture_time(self, filepath):


### PR DESCRIPTION
os.rename() doesn't work when moving files between different devices. It
will lead to OSError: [Errno 18] Cross-device link. Use shutil.move()
instead.

Fixes #154