### PR TITLE
Don't send subsecond value in the datetimeoriginal tag

### DIFF
--- a/mapillary_tools/exif_write.py
+++ b/mapillary_tools/exif_write.py
@@ -35,10 +35,10 @@ class ExifEdit(object):
         else:
             self._ef['0th'][piexif.ImageIFD.Orientation] = orientation
 
-    def add_date_time_original(self, date_time, time_format='%Y:%m:%d %H:%M:%S.%f'):
+    def add_date_time_original(self, date_time, time_format='%Y:%m:%d %H:%M:%S'):
         """Add date time original."""
         try:
-            DateTimeOriginal = date_time.strftime(time_format)[:-3]
+            DateTimeOriginal = date_time.strftime(time_format)
             self._ef['Exif'][piexif.ExifIFD.DateTimeOriginal] = DateTimeOriginal
         except Exception as e:
             print("Error writing DateTimeOriginal, due to " + str(e))


### PR DESCRIPTION
Simple patch to write a clean datetimeoriginal tag without the subsectimeoriginal value.

You can add another method to write the subsectimeoriginal tag, or add the code in this one with a "dispatch" to write the subsectimeoriginal tag if it exists (after a microsecond to subsecond conversion) #272 