### PR TITLE
Fix wrong datetimeoriginal tag writing

### DIFF
--- a/mapillary_tools/exif_write.py
+++ b/mapillary_tools/exif_write.py
@@ -35,10 +35,10 @@ class ExifEdit(object):
         else:
             self._ef['0th'][piexif.ImageIFD.Orientation] = orientation
 
-    def add_date_time_original(self, date_time, time_format='%Y:%m:%d %H:%M:%S'):
+    def add_date_time_original(self, date_time):
         """Add date time original."""
         try:
-            DateTimeOriginal = date_time.strftime(time_format)
+            DateTimeOriginal = date_time.strftime('%Y:%m:%d %H:%M:%S)
             self._ef['Exif'][piexif.ExifIFD.DateTimeOriginal] = DateTimeOriginal
         except Exception as e:
             print("Error writing DateTimeOriginal, due to " + str(e))

--- a/mapillary_tools/exif_write.py
+++ b/mapillary_tools/exif_write.py
@@ -42,6 +42,9 @@ class ExifEdit(object):
             self._ef['Exif'][piexif.ExifIFD.DateTimeOriginal] = DateTimeOriginal
         except Exception as e:
             print("Error writing DateTimeOriginal, due to " + str(e))
+                                                  
+        if date_time.microsecond != 0:
+            self.add_subsectimeoriginal(date_time.microsecond)
             
     def add_subsectimeoriginal(self, subsec_value):
         """Add subsecond value in the subsectimeoriginal exif tag"""

--- a/mapillary_tools/exif_write.py
+++ b/mapillary_tools/exif_write.py
@@ -38,7 +38,7 @@ class ExifEdit(object):
     def add_date_time_original(self, date_time):
         """Add date time original."""
         try:
-            DateTimeOriginal = date_time.strftime('%Y:%m:%d %H:%M:%S)
+            DateTimeOriginal = date_time.strftime('%Y:%m:%d %H:%M:%S')
             self._ef['Exif'][piexif.ExifIFD.DateTimeOriginal] = DateTimeOriginal
         except Exception as e:
             print("Error writing DateTimeOriginal, due to " + str(e))

--- a/mapillary_tools/exif_write.py
+++ b/mapillary_tools/exif_write.py
@@ -42,6 +42,14 @@ class ExifEdit(object):
             self._ef['Exif'][piexif.ExifIFD.DateTimeOriginal] = DateTimeOriginal
         except Exception as e:
             print("Error writing DateTimeOriginal, due to " + str(e))
+            
+    def add_subsectimeoriginal(self, subsec_value):
+        """Add subsecond value in the subsectimeoriginal exif tag"""
+        try:
+            subsec = str(subsec_value).zfill(6)
+            self._ef['Exif'][piexif.ExifIFD.SubSecTimeOriginal] = subsec
+        except Exception as e:
+            print("Error writing SubSecTimeOriginal, due to " + str(e))
 
     def add_lat_lon(self, lat, lon, precision=1e7):
         """Add lat, lon to gps (lat, lon in float)."""


### PR DESCRIPTION
This pull request replace #273 

To comply the exif specifications, the new code:
- doesn't write the subsecond in the DateTimeOriginal exif tag anymore.
- dispatch the microsecond value to the new method add_subsec_time_original.
- this new method convert the microsecond to a subsecond value (as a string) and write the subsectimeoriginal exif tag.
