### PR TITLE
feat: add build script for pyinstaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ docker/dockercontext/mapillary
 tests/integration/mapillary_tools_upload_provider/data/images/.mapillary/logs
 gitversion
 mapillary_run_provider.yml
+build/
+dist/

--- a/mapillary_tools.spec
+++ b/mapillary_tools.spec
@@ -1,0 +1,31 @@
+# -*- mode: python -*-
+
+block_cipher = None
+
+options = [('u', None, 'OPTION')]
+
+a = Analysis(['bin/mapillary_tools'],
+             pathex=['/Users/matias/code/mapillary/mapillary_tools'],
+             binaries=[],
+             datas=[],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          options,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='mapillary_tools',
+          debug=False,
+          strip=False,
+          upx=True,
+          runtime_tmpdir=None,
+          console=True )

--- a/script/build
+++ b/script/build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pip install -r requirements.txt
+pip install pyinstaller
+pyinstaller --onefile mapillary_tools.spec


### PR DESCRIPTION
Add `script/build` to build a standalone `mapillary_tools` binary

Reference issue: https://github.com/mapillary/mapillary_elva/issues/5360