### PR TITLE
feat: add SSL support for OSX

### DIFF
--- a/mapillary_tools.spec
+++ b/mapillary_tools.spec
@@ -5,12 +5,12 @@ block_cipher = None
 options = [('u', None, 'OPTION')]
 
 a = Analysis(['bin/mapillary_tools'],
-             pathex=['/Users/matias/code/mapillary/mapillary_tools'],
+             pathex=[SPECPATH],
              binaries=[],
              datas=[],
              hiddenimports=[],
-             hookspath=[],
-             runtime_hooks=[],
+             hookspath=['./pyinstaller/hooks'],
+             runtime_hooks=['./pyinstaller/runtime-hooks/ssl.py'],
              excludes=[],
              win_no_prefer_redirects=False,
              win_private_assemblies=False,

--- a/pyinstaller/hooks/hook-urllib2.py
+++ b/pyinstaller/hooks/hook-urllib2.py
@@ -1,0 +1,5 @@
+from PyInstaller.compat import is_darwin
+
+if (is_darwin):
+    import certifi
+    datas = [(certifi.where(), 'lib')]

--- a/pyinstaller/runtime-hooks/ssl.py
+++ b/pyinstaller/runtime-hooks/ssl.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+if sys.platform == 'darwin':
+    os.environ['SSL_CERT_FILE'] = os.path.join(sys._MEIPASS, 'lib', 'cacert.pem')


### PR DESCRIPTION
@sbaldassin @jernejaMislej We need to add `pip install certifi` to the build script but only for OSX

Reference issue: mapillary/mapillary_elva#5420