### PR TITLE
Only import pymp4 when needed.

### DIFF
--- a/mapillary_tools/camera_support/prepare_blackvue_videos.py
+++ b/mapillary_tools/camera_support/prepare_blackvue_videos.py
@@ -1,4 +1,3 @@
-from pymp4.parser import Box
 import io
 import sys
 
@@ -13,6 +12,7 @@ def find_camera_model(videos_folder):
     fd.seek(0, io.SEEK_END)
     eof = fd.tell()
     fd.seek(0)
+    from pymp4.parser import Box
     while fd.tell() < eof:
         try:
             box = Box.parse_stream(fd)

--- a/mapillary_tools/gpx_from_blackvue.py
+++ b/mapillary_tools/gpx_from_blackvue.py
@@ -10,8 +10,12 @@ from geo import write_gpx
 from geo import get_max_distance_from_start
 from geo import get_total_distance_traveled
 
-from pymp4.parser import Box
-from construct.core import RangeError, ConstError
+try:
+    from pymp4.parser import Box
+    from construct.core import RangeError, ConstError
+    _has_pymp4 = True
+except:
+    _has_pymp4 = False
 
 '''
 Pulls geo data out of a BlackVue video files
@@ -164,7 +168,10 @@ def is_video_stationary(max_distance_from_start,total_distance_traveled):
 def gpx_from_blackvue(bv_video,use_nmea_stream_timestamp=False):
     bv_data = []
     try:
-        bv_data = get_points_from_bv(bv_video,use_nmea_stream_timestamp)
+        if _has_pymp4:
+            bv_data = get_points_from_bv(bv_video,use_nmea_stream_timestamp)
+        else:
+            raise Exception("missing pymp4.parser or construct.core Python libraries")
     except Exception as e:
         print(
             "Warning, could not extract gps from video {} due to {}, video will be skipped...".format(bv_video, e))

--- a/mapillary_tools/process_video.py
+++ b/mapillary_tools/process_video.py
@@ -9,7 +9,6 @@ from tqdm import tqdm
 import logging
 import io
 import struct
-from pymp4.parser import Box
 
 from exif_write import ExifEdit
 
@@ -225,6 +224,7 @@ def get_video_start_time(video_file):
 
 
 def get_video_start_time_blackvue(video_file):
+    from pymp4.parser import Box
     with open(video_file, 'rb') as fd:
         fd.seek(0, io.SEEK_END)
         eof = fd.tell()


### PR DESCRIPTION
Only few users have BlackVue video files so mapillary-tools should not
force all users to install pymp4.

Signed-off-by: Francois Gouget <fgouget@free.fr>