### PR TITLE
Fix spelling in the processed images mapillary path

### DIFF
--- a/mapillary_tools/processing.py
+++ b/mapillary_tools/processing.py
@@ -715,7 +715,7 @@ def failed_process(file_path, process):
 
 
 def processed_images_rootpath(filepath):
-    return os.path.join(os.path.dirname(filepath), ".mapillary", "proccessed_images", os.path.basename(filepath))
+    return os.path.join(os.path.dirname(filepath), ".mapillary", "processed_images", os.path.basename(filepath))
 
 
 def video_upload(video_file, import_path, verbose=False):


### PR DESCRIPTION
Note that this will cause Mapillary to no longer find the files from
previous runs.

Signed-off-by: Francois Gouget <fgouget@free.fr>