### PR TITLE
fix: ipc encoding on Windows for import paths encoded as cp1252

### DIFF
--- a/mapillary_tools/processing.py
+++ b/mapillary_tools/processing.py
@@ -22,6 +22,7 @@ from gpx_from_exif import gpx_from_exif
 from tqdm import tqdm
 from . import ipc
 from .error import print_error
+from .utils import force_decode
 
 STATUS_PAIRS = {"success": "failed",
                 "failed": "success"
@@ -823,9 +824,11 @@ def create_and_log_process(image, process, status, mapillary_description={}, ver
                     process))
             os.remove(log_MAPJson)
 
+    decoded_image = force_decode(image)
+
     ipc.send(
         process,
-        { 'image': image, 'status': status, 'description': mapillary_description })
+        { 'image': decoded_image, 'status': status, 'description': mapillary_description })
 
 
 def user_properties(user_name,

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -17,6 +17,7 @@ import sys
 import processing
 from . import ipc
 from .error import print_error
+from .utils import force_decode
 
 if os.getenv("AWS_S3_ENDPOINT", None) is None:
     MAPILLARY_UPLOAD_URL = "https://d22zcsn13kp53w.cloudfront.net/"
@@ -723,10 +724,12 @@ def create_upload_log(filepath, status):
         if os.path.isfile(upload_opposite_log_filepath):
             os.remove(upload_opposite_log_filepath)
 
+    decoded_filepath = force_decode(filepath)
+
     ipc.send(
         'upload',
         {
-            'image': filepath,
+            'image': decoded_filepath,
             'status': 'success' if status == 'upload_success' else 'failed',
         })
 

--- a/mapillary_tools/utils.py
+++ b/mapillary_tools/utils.py
@@ -1,0 +1,8 @@
+def force_decode(string, codecs=['utf8', 'cp1252']):
+    for i in codecs:
+        try:
+            return string.decode(i)
+        except UnicodeDecodeError:
+            pass
+    print('cannot decode string: %s' % (string))
+    return string.decode('utf8', errors='replace')


### PR DESCRIPTION
Related to https://github.com/mapillary/mapillary_elva/issues/6624
Required for https://github.com/mapillary/mapillary_tools_for_desktop/pull/36