### PR TITLE
Fix post_process video support and clean up command line options handling

### DIFF
--- a/bin/download_images.py
+++ b/bin/download_images.py
@@ -94,10 +94,10 @@ if __name__ == '__main__':
     parser.add_argument('max_lat', type=float)
     parser.add_argument('min_lon', type=float)
     parser.add_argument('max_lon', type=float)
-    parser.add_argument('--max_results', type=int, default=400)
-    parser.add_argument('--image_size', type=int,
+    parser.add_argument('--max-results', '--max_results', type=int, default=400)
+    parser.add_argument('--image-size', '--image_size', type=int,
                         default=1024, choices=[320, 640, 1024, 2048])
-    parser.add_argument('--output_path', default=None, required=False)
+    parser.add_argument('--output-path', '--output_path', default=None, required=False)
     args = parser.parse_args()
 
     # query api

--- a/bin/mapillary_tools
+++ b/bin/mapillary_tools
@@ -22,12 +22,15 @@ if flag_duplicates:
 # Create the top-level parser
 parser = argparse.ArgumentParser(
     'Mapillary import tool', usage="see -h for available tools and corresponding arguments, add --advanced to see additional advanced tools and/or arguments and --version to see version.")
-parser.add_argument(
-    '--advanced', help='Use the tools under an advanced level with additional arguments and tools available.', action='store_true', required=False, default=False)
-parser.add_argument(
-    '--version', help='Print mapillary tools version.', action='store_true', required=False, default=False)
-parser.add_argument(
-    '--full_help', help='Print full help for all the available commands and their arguments.', action='store_true', required=False, default=False)
+parser.add_argument('--advanced',
+    help='Use the tools under an advanced level with additional arguments and tools available.',
+    action='store_true', required=False, default=False)
+parser.add_argument('--version',
+    help='Print mapillary tools version.',
+    action='store_true', required=False, default=False)
+parser.add_argument('--full_help',
+    help='Print full help for all the available commands and their arguments.',
+    action='store_true', required=False, default=False)
 
 subparsers = parser.add_subparsers(
     help="Please choose one of the available tools", dest='tool', metavar='tool')

--- a/mapillary_tools/commands/__init__.py
+++ b/mapillary_tools/commands/__init__.py
@@ -45,20 +45,24 @@ VERSION = "0.5.3"
 
 
 def add_general_arguments(parser, command):
-    parser.add_argument('--advanced', help='Use the tools under an advanced level with additional arguments and tools available.',
-                        action='store_true', required=False, default=False)
-    parser.add_argument('--version', help='Print mapillary tools version.',
-                        action='store_true', required=False, default=False)
+    parser.add_argument('--advanced',
+        help='Use the tools under an advanced level with additional arguments and tools available.',
+        action='store_true', required=False, default=False)
+    parser.add_argument('--version',
+        help='Print mapillary tools version.',
+        action='store_true', required=False, default=False)
 
     if command == "authenticate":
         return
     # print out warnings
-    parser.add_argument(
-        '--verbose', help='print debug info', action='store_true', default=False, required=False)
+    parser.add_argument('--verbose',
+        help='Print debug information.',
+        action='store_true', default=False, required=False)
     #import path
     required = True
     if command in ["interpolate", "video_process", "video_process_and_upload", "sample_video", "send_videos_for_processing"]:
         required = False
 
-    parser.add_argument(
-        '--import_path', help='path to your photos, or in case of video, path where the photos from video sampling will be saved', required=required)
+    parser.add_argument('--import_path',
+        help='Path to your photos, or in case of video, path where the photos from video sampling will be saved.',
+        required=required)

--- a/mapillary_tools/commands/__init__.py
+++ b/mapillary_tools/commands/__init__.py
@@ -66,3 +66,12 @@ def add_general_arguments(parser, command):
     parser.add_argument('--import_path',
         help='Path to your photos, or in case of video, path where the photos from video sampling will be saved.',
         required=required)
+    if command.startswith(("exif_insert", "extract_", "post_process", "process", "sample_video", "send_videos_for_processing", "video_process")):
+        parser.add_argument('--skip_subfolders',
+            help='Skip all subfolders and import only the images in the given directory path.',
+            action='store_true', default=False, required=False)
+
+    if command.startswith(("exif_insert", "extract_", "process", "video_process")):
+        parser.add_argument('--rerun',
+            help='Rerun the processing.',
+            action='store_true', required=False)

--- a/mapillary_tools/commands/__init__.py
+++ b/mapillary_tools/commands/__init__.py
@@ -63,11 +63,11 @@ def add_general_arguments(parser, command):
     if command in ["interpolate", "video_process", "video_process_and_upload", "sample_video", "send_videos_for_processing"]:
         required = False
 
-    parser.add_argument('--import_path',
+    parser.add_argument('--import-path', '--import_path',
         help='Path to your photos, or in case of video, path where the photos from video sampling will be saved.',
         required=required)
     if command.startswith(("exif_insert", "extract_", "post_process", "process", "sample_video", "send_videos_for_processing", "video_process")):
-        parser.add_argument('--skip_subfolders',
+        parser.add_argument('--skip-subfolders', '--skip_subfolders',
             help='Skip all subfolders and import only the images in the given directory path.',
             action='store_true', default=False, required=False)
 

--- a/mapillary_tools/commands/authenticate.py
+++ b/mapillary_tools/commands/authenticate.py
@@ -1,5 +1,8 @@
 
-from mapillary_tools.edit_config import edit_config
+from mapillary_tools.edit_config import (
+    add_user_auth_arguments,
+    add_edit_config_arguments,
+    edit_config)
 
 
 class Command:
@@ -7,26 +10,11 @@ class Command:
     help = "Helper tool : (Re)run authentication."
 
     def add_basic_arguments(self, parser):
-        parser.add_argument(
-            '--config_file', help='Full path to the config file to be edited. Default is ~/.config/mapillary/configs/MkJKbDA0bnZuZlcxeTJHTmFqN3g1dzo1YTM0NjRkM2EyZGU5MzBh', default=None, required=False)
-        parser.add_argument("--user_name", help="Mapillary user name",
-                            default=None, required=False)
-        parser.add_argument(
-            "--user_email", help="user email, used to create Mapillary account", default=None, required=False)
-        parser.add_argument(
-            "--user_password", help="password associated with the Mapillary user account", default=None, required=False)
-        parser.add_argument(
-            "--jwt", help="JWT authentication token", default=None, required=False)
-        parser.add_argument(
-            '--user_key', help='Manually specify user key', default=False, required=False)
-        parser.add_argument(
-            '--force_overwrite', help='Automatically overwrite any existing credentials stored in the config file for the specified user.', action='store_true', default=False, required=False)
-        parser.add_argument(
-            '--api_version', help='Choose which Mapillary API version to use', default=1.0, required=False)
+        add_user_auth_arguments(parser)
+        add_edit_config_arguments(parser)
 
     def add_advanced_arguments(self, parser):
         pass
 
     def run(self, args):
-
         edit_config(**vars(args))

--- a/mapillary_tools/commands/download.py
+++ b/mapillary_tools/commands/download.py
@@ -1,5 +1,6 @@
 import sys
 import inspect
+from mapillary_tools.process_user_properties import add_user_arguments
 from mapillary_tools.download import download
 from mapillary_tools.download_blurred import download as download_blurred
 
@@ -14,9 +15,7 @@ either for a specified import path or by image keys.
         parser.add_argument("--output_folder",
                             help="Output folder for the downloaded images.",
                             required=True)
-        parser.add_argument("--user_name",
-                            help="user name",
-                            required=True)
+        add_user_arguments(parser)
         parser.add_argument("--by_property",
                             help="Image reference, either UUID or KEY",
                             type=str,

--- a/mapillary_tools/commands/download.py
+++ b/mapillary_tools/commands/download.py
@@ -17,15 +17,15 @@ either for a specified import path or by image keys.
     def add_basic_arguments(self, parser):
         add_user_arguments(parser)
         add_download_basic_arguments(parser)
-        parser.add_argument('--by_property',
+        parser.add_argument('--by-property', '--by_property',
             help="Image reference, either UUID or KEY.",
             type=str, default='uuid',
             choices=['key', 'uuid'])
-        parser.add_argument('--organization_keys',
+        parser.add_argument('--organization-keys', '--organization_keys',
             help="Organizations which own the imagery.")
-        parser.add_argument('--start_time',
+        parser.add_argument('--start-time', '--start_time',
             help="Since when to pull the images (YYYY-MM-DD).")
-        parser.add_argument('--end_time',
+        parser.add_argument('--end-time', '--end_time',
             help="Until when to pull the images (YYYY-MM-DD).")
         parser.add_argument('--private',
             help="Download private/public organization images.",

--- a/mapillary_tools/commands/download.py
+++ b/mapillary_tools/commands/download.py
@@ -1,7 +1,10 @@
 import sys
 import inspect
 from mapillary_tools.process_user_properties import add_user_arguments
-from mapillary_tools.download import download
+from mapillary_tools.download import (
+    add_download_basic_arguments,
+    add_download_advanced_arguments,
+    download)
 from mapillary_tools.download_blurred import download as download_blurred
 
 
@@ -12,10 +15,8 @@ either for a specified import path or by image keys.
 '''
 
     def add_basic_arguments(self, parser):
-        parser.add_argument("--output_folder",
-                            help="Output folder for the downloaded images.",
-                            required=True)
         add_user_arguments(parser)
+        add_download_basic_arguments(parser)
         parser.add_argument("--by_property",
                             help="Image reference, either UUID or KEY",
                             type=str,
@@ -34,12 +35,7 @@ either for a specified import path or by image keys.
                             default='true')
 
     def add_advanced_arguments(self, parser):
-        parser.add_argument(
-            '--number_threads',
-            help='Specify the number of download threads.',
-            type=int,
-            default=10,
-            required=False)
+        add_download_advanced_arguments(parser)
 
     def run(self, args):
 

--- a/mapillary_tools/commands/download.py
+++ b/mapillary_tools/commands/download.py
@@ -17,22 +17,20 @@ either for a specified import path or by image keys.
     def add_basic_arguments(self, parser):
         add_user_arguments(parser)
         add_download_basic_arguments(parser)
-        parser.add_argument("--by_property",
-                            help="Image reference, either UUID or KEY",
-                            type=str,
-                            choices=['key', 'uuid'],
-                            default='uuid')
+        parser.add_argument('--by_property',
+            help="Image reference, either UUID or KEY.",
+            type=str, default='uuid',
+            choices=['key', 'uuid'])
         parser.add_argument('--organization_keys',
-                            help="Organizations which own the imagery")
+            help="Organizations which own the imagery.")
         parser.add_argument('--start_time',
-                            help="Since when to pull the images (YYYY-MM-DD)")
+            help="Since when to pull the images (YYYY-MM-DD).")
         parser.add_argument('--end_time',
-                            help="Until when to pull the images (YYYY-MM-DD)")
+            help="Until when to pull the images (YYYY-MM-DD).")
         parser.add_argument('--private',
-                            help="Download private/public organization images",
-                            type=str,
-                            choices=['true', 'false'],
-                            default='true')
+            help="Download private/public organization images.",
+            type=str, default='true',
+            choices=['true', 'false'])
 
     def add_advanced_arguments(self, parser):
         add_download_advanced_arguments(parser)

--- a/mapillary_tools/commands/exif_insert.py
+++ b/mapillary_tools/commands/exif_insert.py
@@ -7,10 +7,7 @@ class Command:
     help = "Process unit tool : Format and insert Mapillary image description into image EXIF ImageDescription."
 
     def add_basic_arguments(self, parser):
-        parser.add_argument(
-            '--rerun', help='rerun the processing', action='store_true', required=False)
-        parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
+        pass
 
     def add_advanced_arguments(self, parser):
         # master upload

--- a/mapillary_tools/commands/exif_insert.py
+++ b/mapillary_tools/commands/exif_insert.py
@@ -1,5 +1,7 @@
 from mapillary_tools.process_user_properties import add_mapillary_arguments
-from mapillary_tools.insert_MAPJson import insert_MAPJson
+from mapillary_tools.insert_MAPJson import (
+    add_EXIF_insert_arguments,
+    insert_MAPJson)
 
 
 class Command:
@@ -11,21 +13,7 @@ class Command:
 
     def add_advanced_arguments(self, parser):
         add_mapillary_arguments(parser)
-
-        parser.add_argument('--skip_EXIF_insert', help='Skip inserting the extracted data into image EXIF.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--keep_original', help='Do not overwrite original images, instead save the processed images in a new directory called "processed_images" located in .mapillary in the import_path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_all_EXIF_tags', help='Overwrite the rest of the EXIF tags, whose values are changed during the processing. Default is False, which will result in the processed values to be inserted only in the EXIF Image Description tag.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_time_tag', help='Overwrite the capture time EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_gps_tag', help='Overwrite the gps EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_direction_tag', help='Overwrite the camera direction EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_orientation_tag', help='Overwrite the orientation EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
+        add_EXIF_insert_arguments(parser)
 
     def run(self, args):
 

--- a/mapillary_tools/commands/exif_insert.py
+++ b/mapillary_tools/commands/exif_insert.py
@@ -1,4 +1,4 @@
-
+from mapillary_tools.process_user_properties import add_mapillary_arguments
 from mapillary_tools.insert_MAPJson import insert_MAPJson
 
 
@@ -10,9 +10,8 @@ class Command:
         pass
 
     def add_advanced_arguments(self, parser):
-        # master upload
-        parser.add_argument('--master_upload', help='Process images with a master key, note: only used by Mapillary employees',
-                            action='store_true', default=False, required=False)
+        add_mapillary_arguments(parser)
+
         parser.add_argument('--skip_EXIF_insert', help='Skip inserting the extracted data into image EXIF.',
                             action='store_true', default=False, required=False)
         parser.add_argument('--keep_original', help='Do not overwrite original images, instead save the processed images in a new directory called "processed_images" located in .mapillary in the import_path.',

--- a/mapillary_tools/commands/extract_geotag_data.py
+++ b/mapillary_tools/commands/extract_geotag_data.py
@@ -8,10 +8,7 @@ class Command:
     help = "Process unit tool : Extract and process time and location properties."
 
     def add_basic_arguments(self, parser):
-        parser.add_argument(
-            '--rerun', help='rerun the processing', action='store_true', required=False)
-        parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
+        pass
 
     def add_advanced_arguments(self, parser):
         parser.add_argument('--geotag_source', help='Provide the source of date/time and gps information needed for geotagging.', action='store',

--- a/mapillary_tools/commands/extract_geotag_data.py
+++ b/mapillary_tools/commands/extract_geotag_data.py
@@ -1,6 +1,8 @@
 
 from mapillary_tools import process_video
-from mapillary_tools.process_geotag_properties import process_geotag_properties
+from mapillary_tools.process_geotag_properties import (
+    add_geotag_arguments,
+    process_geotag_properties)
 
 
 class Command:
@@ -11,22 +13,7 @@ class Command:
         pass
 
     def add_advanced_arguments(self, parser):
-        parser.add_argument('--geotag_source', help='Provide the source of date/time and gps information needed for geotagging.', action='store',
-                            choices=['exif', 'gpx', 'gopro_videos', 'nmea', "blackvue_videos"], default="exif", required=False)
-        parser.add_argument(
-            '--geotag_source_path', help='Provide the path to the file source of date/time and gps information needed for geotagging.', action='store',
-            default=None, required=False)
-        parser.add_argument(
-            '--local_time', help='Assume image timestamps are in your local time', action='store_true', default=False, required=False)
-        parser.add_argument('--sub_second_interval',
-                            help='Sub second time between shots. Used to set image times with sub-second precision',
-                            type=float, default=0.0, required=False)
-        parser.add_argument('--offset_time', default=0., type=float,
-                            help='time offset between the camera and the gps device, in seconds.', required=False)
-        parser.add_argument('--offset_angle', default=0., type=float,
-                            help='offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing)', required=False)
-        parser.add_argument("--use_gps_start_time",
-                            help="Use GPS trace starting time in case of derivating timestamp from filename.", action="store_true", default=False, required=False)
+        add_geotag_arguments(parser)
 
     def run(self, args):
         vars_args=vars(args)

--- a/mapillary_tools/commands/extract_import_meta_data.py
+++ b/mapillary_tools/commands/extract_import_meta_data.py
@@ -7,10 +7,7 @@ class Command:
     help = "Process unit tool: Extract and process import meta properties."
 
     def add_basic_arguments(self, parser):
-        parser.add_argument(
-            '--rerun', help='rerun the processing', action='store_true', required=False)
-        parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
+        pass
 
     def add_advanced_arguments(self, parser):
 

--- a/mapillary_tools/commands/extract_import_meta_data.py
+++ b/mapillary_tools/commands/extract_import_meta_data.py
@@ -1,5 +1,7 @@
 
-from mapillary_tools.process_import_meta_properties import process_import_meta_properties
+from mapillary_tools.process_import_meta_properties import (
+    add_import_meta_arguments,
+    process_import_meta_properties)
 
 
 class Command:
@@ -10,30 +12,7 @@ class Command:
         pass
 
     def add_advanced_arguments(self, parser):
-
-        # command specific args
-        parser.add_argument(
-            "--device_make", help="Specify device manufacturer. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            "--device_model", help="Specify device model. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            '--add_file_name', help="Add original file name to EXIF. Note this input has precedence over the input read from the import source file.", action='store_true', required=False)
-        parser.add_argument(
-            '--windows_path', help="If local file name is to be added with --add_file_name, added it as a windows path.", action='store_true', required=False)
-        parser.add_argument(
-            '--exclude_import_path', help="If local file name is to be added exclude import_path from the name.", action='store_true', required=False)
-        parser.add_argument(
-            "--exclude_path", help="If local file name is to be added, specify the path to be excluded.", default=None, required=False)
-        parser.add_argument(
-            '--add_import_date', help="Add import date.", action='store_true', required=False)
-        parser.add_argument('--orientation', help='Specify the image orientation in degrees. Note this might result in image rotation. Note this input has precedence over the input read from the import source file.',
-                            choices=[0, 90, 180, 270], type=int, default=None, required=False)
-        parser.add_argument(
-            "--GPS_accuracy", help="GPS accuracy in meters. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            "--camera_uuid", help="Custom string used to differentiate different captures taken with the same camera make and model.", default=None, required=False)
-        parser.add_argument('--custom_meta_data', help='Add custom meta data to all images. Required format of input is a string, consisting of the meta data name, type and value, separated by a comma for each entry, where entries are separated by semicolon. Supported types are long, double, string, boolean, date. Example for two meta data entries "random_name1,double,12.34;random_name2,long,1234"',
-                            default=None, required=False)
+        add_import_meta_arguments(parser)
 
     def run(self, args):
 

--- a/mapillary_tools/commands/extract_sequence_data.py
+++ b/mapillary_tools/commands/extract_sequence_data.py
@@ -1,5 +1,7 @@
-
-from mapillary_tools.process_sequence_properties import process_sequence_properties
+from mapillary_tools.process_geotag_properties import add_offset_angle_argument
+from mapillary_tools.process_sequence_properties import (
+    add_sequence_arguments,
+    process_sequence_properties)
 
 
 class Command:
@@ -10,20 +12,8 @@ class Command:
         pass
 
     def add_advanced_arguments(self, parser):
-        parser.add_argument('--cutoff_distance', default=600., type=float,
-                            help='maximum gps distance in meters within a sequence', required=False)
-        parser.add_argument('--cutoff_time', default=60., type=float,
-                            help='maximum time interval in seconds within a sequence', required=False)
-        parser.add_argument('--interpolate_directions',
-                            help='perform interpolation of directions', action='store_true', required=False)
-        parser.add_argument('--keep_duplicates',
-                            help='keep duplicates, ie do not flag duplicates for upload exclusion, but keep them to be uploaded', action='store_true', required=False, default=False)
-        parser.add_argument('--duplicate_distance', default=0.1, type=float,
-                            help='max distance for two images to be considered duplicates in meters', required=False)
-        parser.add_argument('--duplicate_angle', default=5., type=float,
-                            help='max angle for two images to be considered duplicates in degrees', required=False)
-        parser.add_argument('--offset_angle', default=0., type=float,
-                            help='offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing)', required=False)
+        add_sequence_arguments(parser)
+        add_offset_angle_argument(parser)
 
     def run(self, args):
 

--- a/mapillary_tools/commands/extract_sequence_data.py
+++ b/mapillary_tools/commands/extract_sequence_data.py
@@ -7,10 +7,7 @@ class Command:
     help = "Process unit tool : Extract and process sequence properties."
 
     def add_basic_arguments(self, parser):
-        parser.add_argument(
-            '--rerun', help='rerun the processing', action='store_true', required=False)
-        parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
+        pass
 
     def add_advanced_arguments(self, parser):
         parser.add_argument('--cutoff_distance', default=600., type=float,

--- a/mapillary_tools/commands/extract_upload_params.py
+++ b/mapillary_tools/commands/extract_upload_params.py
@@ -7,12 +7,8 @@ class Command:
     help = "Process unit tool : Extract and process upload parameters."
 
     def add_basic_arguments(self, parser):
-        parser.add_argument(
-            '--rerun', help='rerun the processing', action='store_true', required=False)
         # user name for the import
         parser.add_argument("--user_name", help="user name", required=True)
-        parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
 
     def add_advanced_arguments(self, parser):
         # master upload

--- a/mapillary_tools/commands/extract_upload_params.py
+++ b/mapillary_tools/commands/extract_upload_params.py
@@ -1,4 +1,7 @@
 
+from mapillary_tools.process_user_properties import (
+    add_user_arguments,
+    add_mapillary_arguments)
 from mapillary_tools.process_upload_params import process_upload_params
 
 
@@ -7,14 +10,10 @@ class Command:
     help = "Process unit tool : Extract and process upload parameters."
 
     def add_basic_arguments(self, parser):
-        # user name for the import
-        parser.add_argument("--user_name", help="user name", required=True)
+        add_user_arguments(parser)
 
     def add_advanced_arguments(self, parser):
-        # master upload
-        parser.add_argument('--master_upload', help='Process images with a master key, note: only used by Mapillary employees',
-                            action='store_true', default=False, required=False)
+        add_mapillary_arguments(parser)
 
     def run(self, args):
-
         process_upload_params(**vars(args))

--- a/mapillary_tools/commands/extract_user_data.py
+++ b/mapillary_tools/commands/extract_user_data.py
@@ -7,8 +7,6 @@ class Command:
     help = "Process unit tool : Extract and process user properties."
 
     def add_basic_arguments(self, parser):
-        parser.add_argument(
-            '--rerun', help='rerun the processing', action='store_true', required=False)
         # user name for the import
         parser.add_argument("--user_name", help="user name", required=True)
         # organization level parameters
@@ -18,8 +16,6 @@ class Command:
             '--organization_key', help="Specify organization key", default=None, required=False)
         parser.add_argument('--private',
                             help="Specify whether the import is private", action='store_true', default=False, required=False)
-        parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
 
     def add_advanced_arguments(self, parser):
         # master upload

--- a/mapillary_tools/commands/extract_user_data.py
+++ b/mapillary_tools/commands/extract_user_data.py
@@ -1,5 +1,9 @@
 
-from mapillary_tools.process_user_properties import process_user_properties
+from mapillary_tools.process_user_properties import (
+    add_user_arguments,
+    add_organization_arguments,
+    add_mapillary_arguments,
+    process_user_properties)
 
 
 class Command:
@@ -7,20 +11,11 @@ class Command:
     help = "Process unit tool : Extract and process user properties."
 
     def add_basic_arguments(self, parser):
-        # user name for the import
-        parser.add_argument("--user_name", help="user name", required=True)
-        # organization level parameters
-        parser.add_argument(
-            '--organization_username', help="Specify organization user name", default=None, required=False)
-        parser.add_argument(
-            '--organization_key', help="Specify organization key", default=None, required=False)
-        parser.add_argument('--private',
-                            help="Specify whether the import is private", action='store_true', default=False, required=False)
+        add_user_arguments(parser)
+        add_organization_arguments(parser)
 
     def add_advanced_arguments(self, parser):
-        # master upload
-        parser.add_argument('--master_upload', help='Process images with a master key, note: only used by Mapillary employees',
-                            action='store_true', default=False, required=False)
+        add_mapillary_arguments(parser)
 
     def run(self, args):
         process_user_properties(**vars(args))

--- a/mapillary_tools/commands/interpolate.py
+++ b/mapillary_tools/commands/interpolate.py
@@ -1,4 +1,6 @@
-from mapillary_tools.interpolation import interpolation
+from mapillary_tools.interpolation import (
+    add_interpolation_arguments,
+    interpolation)
 
 
 class Command:
@@ -6,27 +8,7 @@ class Command:
     help = "Preprocess tool : Interpolate missing gps, identical timestamps, etc..."
 
     def add_basic_arguments(self, parser):
-        parser.add_argument('--data', action='store',
-                            choices=['missing_gps', 'identical_timestamps'],
-                            help='Specify which data you want to interpolate.', required=True)
-        parser.add_argument('--max_time_delta', default=1., type=float,
-                            help='Maximum delta time in seconds, for an image with a timestamp out of scope to have missing gps extrapolated.', required=False)
-        parser.add_argument(
-            '--file_in_path', help='Input file path, in case the identical timestamps to be interpolated are in an external file.', required=False)
-        parser.add_argument('--file_format',
-                            help='Format of the input file, only csv supported for now.', required=False, default="csv")
-        parser.add_argument('--time_column', help='Column with the timestamps, in case interpolating missing timestamps in a csv file.',
-                            required=False, type=int, default=0)
-        parser.add_argument(
-            '--delimiter', help="Delimiter between the columns, in case interpolating missing timestamps in a csv file.", default=",", required=False)
-        parser.add_argument('--time_utc', help='Is the timestamp in utc',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--time_format', help="Time format in a string",
-                            default='%Y-%m-%dT%H:%M:%SZ', required=False)
-        parser.add_argument('--header', help="Specify whether the csv file includes a header, in case interpolating missing timestamps in a csv file..",
-                            default=False, required=False, action='store_true')
-        parser.add_argument('--keep_original', help='Do not overwrite original file, instead save the file with interpolated times in a new file by adding suffix "_processed" to the input file.',
-                            action='store_true', default=False, required=False)
+        add_interpolation_arguments(parser)
 
     def add_advanced_arguments(self, parser):
         pass

--- a/mapillary_tools/commands/post_process.py
+++ b/mapillary_tools/commands/post_process.py
@@ -1,5 +1,7 @@
 import inspect
-from mapillary_tools.post_process import post_process
+from mapillary_tools.post_process import (
+    add_post_process_arguments,
+    post_process)
 
 
 class Command:
@@ -11,30 +13,11 @@ class Command:
 
     def add_advanced_arguments(self, parser):
         # video
-        parser.add_argument('--video_import_path', help='Path to a video or a directory with one or more video files.',
-                            action='store', default=None, required=False)
+        parser.add_argument('--video_import_path',
+            help='Path to a video or a directory with one or more video files.',
+            action='store', default=None, required=False)
 
-        # post process
-        parser.add_argument('--summarize', help='Summarize import for given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_all_images', help='Move all images in import_path according to import state.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_duplicates', help='Move images in case they were flagged as duplicates.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_uploaded', help='Move images according to upload state.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_sequences', help='Move images into sequence folders.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--save_as_json', help='Save summary or file status list in a json.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--list_file_status', help='List file status for given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--push_images', help='Push images uploaded in given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--split_import_path', help='Provide the path where the images should be moved to based on the import status.',
-                            action='store', required=False, default=None)
-        parser.add_argument('--save_local_mapping', help='Save the mapillary photo uuid to local file mapping in a csv.',
-                            action='store_true', default=False, required=False)
+        add_post_process_arguments(parser)
 
     def run(self, args):
 

--- a/mapillary_tools/commands/post_process.py
+++ b/mapillary_tools/commands/post_process.py
@@ -7,9 +7,7 @@ class Command:
     help = 'Post process tool : Post process for a given import path, including import summary and grouping/moving based on import status.'
 
     def add_basic_arguments(self, parser):
-
-        parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
+        pass
 
     def add_advanced_arguments(self, parser):
         # video

--- a/mapillary_tools/commands/post_process.py
+++ b/mapillary_tools/commands/post_process.py
@@ -12,9 +12,9 @@ class Command:
             '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
 
     def add_advanced_arguments(self, parser):
-        # video file
-        parser.add_argument('--video_file', help='Provide the path to a video file or a directory containing a set of Blackvue video files.',
-                            action='store', required=False, default=None)
+        # video
+        parser.add_argument('--video_import_path', help='Path to a video or a directory with one or more video files.',
+                            action='store', default=None, required=False)
 
         # post process
         parser.add_argument('--summarize', help='Summarize import for given import path.',

--- a/mapillary_tools/commands/post_process.py
+++ b/mapillary_tools/commands/post_process.py
@@ -13,7 +13,7 @@ class Command:
 
     def add_advanced_arguments(self, parser):
         # video
-        parser.add_argument('--video_import_path',
+        parser.add_argument('--video-import-path', '--video_import_path',
             help='Path to a video or a directory with one or more video files.',
             action='store', default=None, required=False)
 

--- a/mapillary_tools/commands/process.py
+++ b/mapillary_tools/commands/process.py
@@ -1,5 +1,9 @@
 import inspect
-from mapillary_tools.process_user_properties import process_user_properties
+from mapillary_tools.process_user_properties import (
+    add_user_arguments,
+    add_organization_arguments,
+    add_mapillary_arguments,
+    process_user_properties)
 from mapillary_tools.process_import_meta_properties import process_import_meta_properties
 from mapillary_tools.process_geotag_properties import process_geotag_properties
 from mapillary_tools.process_sequence_properties import process_sequence_properties
@@ -13,21 +17,12 @@ class Command:
     help = 'Main tool : Process image meta data and insert it in image EXIF.'
 
     def add_basic_arguments(self, parser):
-        # user properties
-        # user name for the import
-        parser.add_argument("--user_name", help="user name", required=True)
-        # organization level parameters
-        parser.add_argument(
-            '--organization_username', help="Specify organization user name", default=None, required=False)
-        parser.add_argument(
-            '--organization_key', help="Specify organization key", default=None, required=False)
-        parser.add_argument('--private',
-                            help="Specify whether the import is private", action='store_true', default=False, required=False)
+        add_user_arguments(parser)
+        add_organization_arguments(parser)
 
     def add_advanced_arguments(self, parser):
-        # master upload
-        parser.add_argument('--master_upload', help='Process images with a master key, note: only used by Mapillary employees',
-                            action='store_true', default=False, required=False)
+        add_mapillary_arguments(parser)
+
         #import meta
         parser.add_argument(
             "--device_make", help="Specify device manufacturer. Note this input has precedence over the input read from the import source file.", default=None, required=False)

--- a/mapillary_tools/commands/process.py
+++ b/mapillary_tools/commands/process.py
@@ -13,8 +13,6 @@ class Command:
     help = 'Main tool : Process image meta data and insert it in image EXIF.'
 
     def add_basic_arguments(self, parser):
-        parser.add_argument(
-            '--rerun', help='rerun the processing', action='store_true', required=False)
         # user properties
         # user name for the import
         parser.add_argument("--user_name", help="user name", required=True)
@@ -25,8 +23,6 @@ class Command:
             '--organization_key', help="Specify organization key", default=None, required=False)
         parser.add_argument('--private',
                             help="Specify whether the import is private", action='store_true', default=False, required=False)
-        parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
 
     def add_advanced_arguments(self, parser):
         # master upload

--- a/mapillary_tools/commands/process.py
+++ b/mapillary_tools/commands/process.py
@@ -7,7 +7,9 @@ from mapillary_tools.process_user_properties import (
 from mapillary_tools.process_import_meta_properties import (
     add_import_meta_arguments,
     process_import_meta_properties)
-from mapillary_tools.process_geotag_properties import process_geotag_properties
+from mapillary_tools.process_geotag_properties import (
+    add_geotag_arguments,
+    process_geotag_properties)
 from mapillary_tools.process_sequence_properties import process_sequence_properties
 from mapillary_tools.process_upload_params import process_upload_params
 from mapillary_tools.insert_MAPJson import insert_MAPJson
@@ -25,24 +27,7 @@ class Command:
     def add_advanced_arguments(self, parser):
         add_mapillary_arguments(parser)
         add_import_meta_arguments(parser)
-
-        # geotagging
-        parser.add_argument('--geotag_source', help='Provide the source of date/time and gps information needed for geotagging.', action='store',
-                            choices=['exif', 'gpx', 'gopro_videos', 'nmea', 'blackvue_videos'], default="exif", required=False)
-        parser.add_argument(
-            '--geotag_source_path', help='Provide the path to the file source of date/time and gps information needed for geotagging.', action='store',
-            default=None, required=False)
-        parser.add_argument(
-            '--local_time', help='Assume image timestamps are in your local time', action='store_true', default=False, required=False)
-        parser.add_argument('--sub_second_interval',
-                            help='Sub second time between shots. Used to set image times with sub-second precision',
-                            type=float, default=0.0, required=False)
-        parser.add_argument('--offset_time', default=0., type=float,
-                            help='time offset between the camera and the gps device, in seconds.', required=False)
-        parser.add_argument('--offset_angle', default=0., type=float,
-                            help='offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing)', required=False)
-        parser.add_argument("--use_gps_start_time",
-                            help="Use GPS trace starting time in case of derivating timestamp from filename.", action="store_true", default=False, required=False)
+        add_geotag_arguments(parser)
 
         # sequence
         parser.add_argument('--cutoff_distance', default=600., type=float,

--- a/mapillary_tools/commands/process.py
+++ b/mapillary_tools/commands/process.py
@@ -4,7 +4,9 @@ from mapillary_tools.process_user_properties import (
     add_organization_arguments,
     add_mapillary_arguments,
     process_user_properties)
-from mapillary_tools.process_import_meta_properties import process_import_meta_properties
+from mapillary_tools.process_import_meta_properties import (
+    add_import_meta_arguments,
+    process_import_meta_properties)
 from mapillary_tools.process_geotag_properties import process_geotag_properties
 from mapillary_tools.process_sequence_properties import process_sequence_properties
 from mapillary_tools.process_upload_params import process_upload_params
@@ -22,28 +24,7 @@ class Command:
 
     def add_advanced_arguments(self, parser):
         add_mapillary_arguments(parser)
-
-        #import meta
-        parser.add_argument(
-            "--device_make", help="Specify device manufacturer. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            "--device_model", help="Specify device model. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            '--add_file_name', help="Add original file name to EXIF. Note this input has precedence over the input read from the import source file.", action='store_true', required=False)
-        parser.add_argument(
-            '--exclude_import_path', help="If local file name is to be added exclude import_path from the name.", action='store_true', required=False)
-        parser.add_argument(
-            "--exclude_path", help="If local file name is to be added, specify the path to be excluded.", default=None, required=False)
-        parser.add_argument(
-            '--add_import_date', help="Add import date.", action='store_true', required=False)
-        parser.add_argument(
-            '--windows_path', help="If local file name is to be added with --add_file_name, added it as a windows path.", action='store_true', required=False)
-        parser.add_argument('--orientation', help='Specify the image orientation in degrees. Note this might result in image rotation. Note this input has precedence over the input read from the import source file.',
-                            choices=[0, 90, 180, 270], type=int, default=None, required=False)
-        parser.add_argument(
-            "--GPS_accuracy", help="GPS accuracy in meters. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            "--camera_uuid", help="Custom string used to differentiate different captures taken with the same camera make and model.", default=None, required=False)
+        add_import_meta_arguments(parser)
 
         # geotagging
         parser.add_argument('--geotag_source', help='Provide the source of date/time and gps information needed for geotagging.', action='store',
@@ -114,10 +95,6 @@ class Command:
                             action='store_true', default=False, required=False)
         parser.add_argument('--overwrite_EXIF_orientation_tag', help='Overwrite the orientation EXIF tag with the value obtained in process.',
                             action='store_true', default=False, required=False)
-        # add custom meta data in a form of a string consisting of a triplet
-        # "name,type,value"
-        parser.add_argument('--custom_meta_data', help='Add custom meta data to all images. Required format of input is a string, consisting of the meta data name, type and value, separated by a comma for each entry, where entries are separated by semicolon. Supported types are long, double, string, boolean, date. Example for two meta data entries "random_name1,double,12.34;random_name2,long,1234"',
-                            default=None, required=False)
 
     def run(self, args):
 

--- a/mapillary_tools/commands/process.py
+++ b/mapillary_tools/commands/process.py
@@ -17,7 +17,9 @@ from mapillary_tools.process_upload_params import process_upload_params
 from mapillary_tools.insert_MAPJson import (
     add_EXIF_insert_arguments,
     insert_MAPJson)
-from mapillary_tools.post_process import post_process
+from mapillary_tools.post_process import (
+    add_post_process_arguments,
+    post_process)
 
 
 class Command:
@@ -34,28 +36,7 @@ class Command:
         add_geotag_arguments(parser)
         add_sequence_arguments(parser)
         add_EXIF_insert_arguments(parser)
-
-        # post process
-        parser.add_argument('--summarize', help='Summarize import for given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_all_images', help='Move all images in import_path according to import state.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_duplicates', help='Move images in case they were flagged as duplicates.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_uploaded', help='Move images according to upload state.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_sequences', help='Move images into sequence folders.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--save_as_json', help='Save summary or file status list in a json.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--list_file_status', help='List file status for given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--push_images', help='Push images uploaded in given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument(
-            '--split_import_path', help='If splitting the import path into duplicates, sequences, success and failed uploads, provide a path for the splits.', default=None, required=False)
-        parser.add_argument('--save_local_mapping', help='Save the mapillary photo uuid to local file mapping in a csv.',
-                            action='store_true', default=False, required=False)
+        add_post_process_arguments(parser)
 
     def run(self, args):
 

--- a/mapillary_tools/commands/process.py
+++ b/mapillary_tools/commands/process.py
@@ -10,7 +10,9 @@ from mapillary_tools.process_import_meta_properties import (
 from mapillary_tools.process_geotag_properties import (
     add_geotag_arguments,
     process_geotag_properties)
-from mapillary_tools.process_sequence_properties import process_sequence_properties
+from mapillary_tools.process_sequence_properties import (
+    add_sequence_arguments,
+    process_sequence_properties)
 from mapillary_tools.process_upload_params import process_upload_params
 from mapillary_tools.insert_MAPJson import insert_MAPJson
 from mapillary_tools.post_process import post_process
@@ -28,20 +30,7 @@ class Command:
         add_mapillary_arguments(parser)
         add_import_meta_arguments(parser)
         add_geotag_arguments(parser)
-
-        # sequence
-        parser.add_argument('--cutoff_distance', default=600., type=float,
-                            help='maximum gps distance in meters within a sequence', required=False)
-        parser.add_argument('--cutoff_time', default=60., type=float,
-                            help='maximum time interval in seconds within a sequence', required=False)
-        parser.add_argument('--interpolate_directions',
-                            help='perform interploation of directions', action='store_true', required=False)
-        parser.add_argument('--keep_duplicates',
-                            help='keep duplicates, ie do not flag duplicates for upload exclusion, but keep them to be uploaded', action='store_true', required=False, default=False)
-        parser.add_argument('--duplicate_distance',
-                            help='max distance for two images to be considered duplicates in meters', type=float, default=0.1, required=False)
-        parser.add_argument(
-            '--duplicate_angle', help='max angle for two images to be considered duplicates in degrees', type=float, default=5, required=False)
+        add_sequence_arguments(parser)
 
         # EXIF insert
         parser.add_argument('--skip_EXIF_insert', help='Skip inserting the extracted data into image EXIF.',

--- a/mapillary_tools/commands/process.py
+++ b/mapillary_tools/commands/process.py
@@ -14,7 +14,9 @@ from mapillary_tools.process_sequence_properties import (
     add_sequence_arguments,
     process_sequence_properties)
 from mapillary_tools.process_upload_params import process_upload_params
-from mapillary_tools.insert_MAPJson import insert_MAPJson
+from mapillary_tools.insert_MAPJson import (
+    add_EXIF_insert_arguments,
+    insert_MAPJson)
 from mapillary_tools.post_process import post_process
 
 
@@ -31,12 +33,7 @@ class Command:
         add_import_meta_arguments(parser)
         add_geotag_arguments(parser)
         add_sequence_arguments(parser)
-
-        # EXIF insert
-        parser.add_argument('--skip_EXIF_insert', help='Skip inserting the extracted data into image EXIF.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--keep_original', help='Do not overwrite original images, instead save the processed images in a new directory called "processed_images" located in .mapillary in the import_path.',
-                            action='store_true', default=False, required=False)
+        add_EXIF_insert_arguments(parser)
 
         # post process
         parser.add_argument('--summarize', help='Summarize import for given import path.',
@@ -58,16 +55,6 @@ class Command:
         parser.add_argument(
             '--split_import_path', help='If splitting the import path into duplicates, sequences, success and failed uploads, provide a path for the splits.', default=None, required=False)
         parser.add_argument('--save_local_mapping', help='Save the mapillary photo uuid to local file mapping in a csv.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_all_EXIF_tags', help='Overwrite the rest of the EXIF tags, whose values are changed during the processing. Default is False, which will result in the processed values to be inserted only in the EXIF Image Description tag.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_time_tag', help='Overwrite the capture time EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_gps_tag', help='Overwrite the gps EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_direction_tag', help='Overwrite the camera direction EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_orientation_tag', help='Overwrite the orientation EXIF tag with the value obtained in process.',
                             action='store_true', default=False, required=False)
 
     def run(self, args):

--- a/mapillary_tools/commands/process_and_upload.py
+++ b/mapillary_tools/commands/process_and_upload.py
@@ -7,7 +7,9 @@ from mapillary_tools.process_user_properties import (
 from mapillary_tools.process_import_meta_properties import (
     add_import_meta_arguments,
     process_import_meta_properties)
-from mapillary_tools.process_geotag_properties import process_geotag_properties
+from mapillary_tools.process_geotag_properties import (
+    add_geotag_arguments,
+    process_geotag_properties)
 from mapillary_tools.process_sequence_properties import process_sequence_properties
 from mapillary_tools.process_upload_params import process_upload_params
 from mapillary_tools.insert_MAPJson import insert_MAPJson
@@ -26,24 +28,7 @@ class Command:
     def add_advanced_arguments(self, parser):
         add_mapillary_arguments(parser)
         add_import_meta_arguments(parser)
-
-        # geotagging
-        parser.add_argument('--geotag_source', help='Provide the source of date/time and gps information needed for geotagging.', action='store',
-                            choices=['exif', 'gpx', 'gopro_videos', 'nmea', 'blackvue_videos'], default="exif", required=False)
-        parser.add_argument(
-            '--geotag_source_path', help='Provide the path to the file source of date/time and gps information needed for geotagging.', action='store',
-            default=None, required=False)
-        parser.add_argument(
-            '--local_time', help='Assume image timestamps are in your local time', action='store_true', default=False, required=False)
-        parser.add_argument('--sub_second_interval',
-                            help='Sub second time between shots. Used to set image times with sub-second precision',
-                            type=float, default=0.0, required=False)
-        parser.add_argument('--offset_time', default=0., type=float,
-                            help='time offset between the camera and the gps device, in seconds.', required=False)
-        parser.add_argument('--offset_angle', default=0., type=float,
-                            help='offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing)', required=False)
-        parser.add_argument("--use_gps_start_time",
-                            help="Use GPS trace starting time in case of derivating timestamp from filename.", action="store_true", default=False, required=False)
+        add_geotag_arguments(parser)
 
         # sequence
         parser.add_argument('--cutoff_distance', default=600., type=float,

--- a/mapillary_tools/commands/process_and_upload.py
+++ b/mapillary_tools/commands/process_and_upload.py
@@ -20,7 +20,9 @@ from mapillary_tools.insert_MAPJson import (
 from mapillary_tools.upload import (
     add_upload_arguments,
     upload)
-from mapillary_tools.post_process import post_process
+from mapillary_tools.post_process import (
+    add_post_process_arguments,
+    post_process)
 
 
 class Command:
@@ -38,28 +40,7 @@ class Command:
         add_sequence_arguments(parser)
         add_EXIF_insert_arguments(parser)
         add_upload_arguments(parser)
-
-        # post process
-        parser.add_argument('--summarize', help='Summarize import for given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_all_images', help='Move all images in import_path according to import state.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_duplicates', help='Move images in case they were flagged as duplicates.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_uploaded', help='Move images according to upload state.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_sequences', help='Move images into sequence folders.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--save_as_json', help='Save summary or file status list in a json.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--list_file_status', help='List file status for given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--push_images', help='Push images uploaded in given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument(
-            '--split_import_path', help='If splitting the import path into duplicates, sequences, success and failed uploads, provide a path for the splits.', default=None, required=False)
-        parser.add_argument('--save_local_mapping', help='Save the mapillary photo uuid to local file mapping in a csv.',
-                            action='store_true', default=False, required=False)
+        add_post_process_arguments(parser)
 
     def run(self, args):
 

--- a/mapillary_tools/commands/process_and_upload.py
+++ b/mapillary_tools/commands/process_and_upload.py
@@ -14,8 +14,6 @@ class Command:
     help = "Batch tool : Process images and upload to Mapillary."
 
     def add_basic_arguments(self, parser):
-        parser.add_argument(
-            '--rerun', help='rerun the processing', action='store_true', required=False)
         # user properties
         # user name for the import
         parser.add_argument("--user_name", help="user name", required=True)
@@ -26,8 +24,6 @@ class Command:
             '--organization_key', help="Specify organization key", default=None, required=False)
         parser.add_argument('--private',
                             help="Specify whether the import is private", action='store_true', default=False, required=False)
-        parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
 
     def add_advanced_arguments(self, parser):
         # master upload

--- a/mapillary_tools/commands/process_and_upload.py
+++ b/mapillary_tools/commands/process_and_upload.py
@@ -14,7 +14,9 @@ from mapillary_tools.process_sequence_properties import (
     add_sequence_arguments,
     process_sequence_properties)
 from mapillary_tools.process_upload_params import process_upload_params
-from mapillary_tools.insert_MAPJson import insert_MAPJson
+from mapillary_tools.insert_MAPJson import (
+    add_EXIF_insert_arguments,
+    insert_MAPJson)
 from mapillary_tools.upload import upload
 from mapillary_tools.post_process import post_process
 
@@ -32,12 +34,8 @@ class Command:
         add_import_meta_arguments(parser)
         add_geotag_arguments(parser)
         add_sequence_arguments(parser)
+        add_EXIF_insert_arguments(parser)
 
-        # EXIF insert
-        parser.add_argument('--skip_EXIF_insert', help='Skip inserting the extracted data into image EXIF.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--keep_original', help='Do not overwrite original images, instead save the processed images in a new directory called "processed_images" located in .mapillary in the import_path.',
-                            action='store_true', default=False, required=False)
         parser.add_argument(
             '--number_threads', help='Specify the number of upload threads.', type=int, default=None, required=False)
         parser.add_argument(
@@ -63,16 +61,6 @@ class Command:
         parser.add_argument(
             '--split_import_path', help='If splitting the import path into duplicates, sequences, success and failed uploads, provide a path for the splits.', default=None, required=False)
         parser.add_argument('--save_local_mapping', help='Save the mapillary photo uuid to local file mapping in a csv.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_all_EXIF_tags', help='Overwrite the rest of the EXIF tags, whose values are changed during the processing. Default is False, which will result in the processed values to be inserted only in the EXIF Image Description tag.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_time_tag', help='Overwrite the capture time EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_gps_tag', help='Overwrite the gps EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_direction_tag', help='Overwrite the camera direction EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_orientation_tag', help='Overwrite the orientation EXIF tag with the value obtained in process.',
                             action='store_true', default=False, required=False)
 
     def run(self, args):

--- a/mapillary_tools/commands/process_and_upload.py
+++ b/mapillary_tools/commands/process_and_upload.py
@@ -10,7 +10,9 @@ from mapillary_tools.process_import_meta_properties import (
 from mapillary_tools.process_geotag_properties import (
     add_geotag_arguments,
     process_geotag_properties)
-from mapillary_tools.process_sequence_properties import process_sequence_properties
+from mapillary_tools.process_sequence_properties import (
+    add_sequence_arguments,
+    process_sequence_properties)
 from mapillary_tools.process_upload_params import process_upload_params
 from mapillary_tools.insert_MAPJson import insert_MAPJson
 from mapillary_tools.upload import upload
@@ -29,20 +31,8 @@ class Command:
         add_mapillary_arguments(parser)
         add_import_meta_arguments(parser)
         add_geotag_arguments(parser)
+        add_sequence_arguments(parser)
 
-        # sequence
-        parser.add_argument('--cutoff_distance', default=600., type=float,
-                            help='maximum gps distance in meters within a sequence', required=False)
-        parser.add_argument('--cutoff_time', default=60., type=float,
-                            help='maximum time interval in seconds within a sequence', required=False)
-        parser.add_argument('--interpolate_directions',
-                            help='perform interploation of directions', action='store_true', required=False)
-        parser.add_argument('--keep_duplicates',
-                            help='keep duplicates, ie do not flag duplicates for upload exclusion, but keep them to be uploaded', action='store_true', required=False, default=False)
-        parser.add_argument('--duplicate_distance',
-                            help='max distance for two images to be considered duplicates in meters', type=float, default=0.1, required=False)
-        parser.add_argument(
-            '--duplicate_angle', help='max angle for two images to be considered duplicates in degrees', type=float, default=5, required=False)
         # EXIF insert
         parser.add_argument('--skip_EXIF_insert', help='Skip inserting the extracted data into image EXIF.',
                             action='store_true', default=False, required=False)

--- a/mapillary_tools/commands/process_and_upload.py
+++ b/mapillary_tools/commands/process_and_upload.py
@@ -4,7 +4,9 @@ from mapillary_tools.process_user_properties import (
     add_organization_arguments,
     add_mapillary_arguments,
     process_user_properties)
-from mapillary_tools.process_import_meta_properties import process_import_meta_properties
+from mapillary_tools.process_import_meta_properties import (
+    add_import_meta_arguments,
+    process_import_meta_properties)
 from mapillary_tools.process_geotag_properties import process_geotag_properties
 from mapillary_tools.process_sequence_properties import process_sequence_properties
 from mapillary_tools.process_upload_params import process_upload_params
@@ -23,28 +25,7 @@ class Command:
 
     def add_advanced_arguments(self, parser):
         add_mapillary_arguments(parser)
-
-        #import meta
-        parser.add_argument(
-            "--device_make", help="Specify device manufacturer. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            "--device_model", help="Specify device model. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            '--add_file_name', help="Add original file name to EXIF. Note this input has precedence over the input read from the import source file.", action='store_true', required=False)
-        parser.add_argument(
-            '--windows_path', help="If local file name is to be added with --add_file_name, added it as a windows path.", action='store_true', required=False)
-        parser.add_argument(
-            '--exclude_import_path', help="If local file name is to be added exclude import_path from the name.", action='store_true', required=False)
-        parser.add_argument(
-            "--exclude_path", help="If local file name is to be added, specify the path to be excluded.", default=None, required=False)
-        parser.add_argument(
-            '--add_import_date', help="Add import date.", action='store_true', required=False)
-        parser.add_argument('--orientation', help='Specify the image orientation in degrees. Note this might result in image rotation. Note this input has precedence over the input read from the import source file.',
-                            choices=[0, 90, 180, 270], type=int, default=None, required=False)
-        parser.add_argument(
-            "--GPS_accuracy", help="GPS accuracy in meters. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            "--camera_uuid", help="Custom string used to differentiate different captures taken with the same camera make and model.", default=None, required=False)
+        add_import_meta_arguments(parser)
 
         # geotagging
         parser.add_argument('--geotag_source', help='Provide the source of date/time and gps information needed for geotagging.', action='store',
@@ -118,10 +99,6 @@ class Command:
                             action='store_true', default=False, required=False)
         parser.add_argument('--overwrite_EXIF_orientation_tag', help='Overwrite the orientation EXIF tag with the value obtained in process.',
                             action='store_true', default=False, required=False)
-        # add custom meta data in a form of a string consisting of a triplet
-        # "name,type,value"
-        parser.add_argument('--custom_meta_data', help='Add custom meta data to all images. Required format of input is a string, consisting of the meta data name, type and value, separated by a comma for each entry, where entries are separated by semicolon. Supported types are long, double, string, boolean, date. Example for two meta data entries "random_name1,double,12.34;random_name2,long,1234"',
-                            default=None, required=False)
 
     def run(self, args):
 

--- a/mapillary_tools/commands/process_and_upload.py
+++ b/mapillary_tools/commands/process_and_upload.py
@@ -1,5 +1,9 @@
 import inspect
-from mapillary_tools.process_user_properties import process_user_properties
+from mapillary_tools.process_user_properties import (
+    add_user_arguments,
+    add_organization_arguments,
+    add_mapillary_arguments,
+    process_user_properties)
 from mapillary_tools.process_import_meta_properties import process_import_meta_properties
 from mapillary_tools.process_geotag_properties import process_geotag_properties
 from mapillary_tools.process_sequence_properties import process_sequence_properties
@@ -14,21 +18,12 @@ class Command:
     help = "Batch tool : Process images and upload to Mapillary."
 
     def add_basic_arguments(self, parser):
-        # user properties
-        # user name for the import
-        parser.add_argument("--user_name", help="user name", required=True)
-        # organization level parameters
-        parser.add_argument(
-            '--organization_username', help="Specify organization user name", default=None, required=False)
-        parser.add_argument(
-            '--organization_key', help="Specify organization key", default=None, required=False)
-        parser.add_argument('--private',
-                            help="Specify whether the import is private", action='store_true', default=False, required=False)
+        add_user_arguments(parser)
+        add_organization_arguments(parser)
 
     def add_advanced_arguments(self, parser):
-        # master upload
-        parser.add_argument('--master_upload', help='Process images with a master key, note: only used by Mapillary employees',
-                            action='store_true', default=False, required=False)
+        add_mapillary_arguments(parser)
+
         #import meta
         parser.add_argument(
             "--device_make", help="Specify device manufacturer. Note this input has precedence over the input read from the import source file.", default=None, required=False)

--- a/mapillary_tools/commands/process_and_upload.py
+++ b/mapillary_tools/commands/process_and_upload.py
@@ -17,7 +17,9 @@ from mapillary_tools.process_upload_params import process_upload_params
 from mapillary_tools.insert_MAPJson import (
     add_EXIF_insert_arguments,
     insert_MAPJson)
-from mapillary_tools.upload import upload
+from mapillary_tools.upload import (
+    add_upload_arguments,
+    upload)
 from mapillary_tools.post_process import post_process
 
 
@@ -35,11 +37,7 @@ class Command:
         add_geotag_arguments(parser)
         add_sequence_arguments(parser)
         add_EXIF_insert_arguments(parser)
-
-        parser.add_argument(
-            '--number_threads', help='Specify the number of upload threads.', type=int, default=None, required=False)
-        parser.add_argument(
-            '--max_attempts', help='Specify the maximum number of attempts to upload.', type=int, default=None, required=False)
+        add_upload_arguments(parser)
 
         # post process
         parser.add_argument('--summarize', help='Summarize import for given import path.',

--- a/mapillary_tools/commands/process_csv.py
+++ b/mapillary_tools/commands/process_csv.py
@@ -1,5 +1,8 @@
 
-from mapillary_tools.process_csv import process_csv
+from mapillary_tools.process_csv import (
+    add_process_csv_basic_arguments,
+    add_process_csv_advanced_arguments,
+    process_csv)
 
 
 class Command:
@@ -7,42 +10,10 @@ class Command:
     help = "Preprocess tool : Parse csv and preprocess the images, to enable running process_and_upload."
 
     def add_basic_arguments(self, parser):
-        parser.add_argument(
-            '--csv_path', help='Provide the path to the csv file.', action='store', required=True)
-        parser.add_argument('--delimiter', help='Delimiter between the columns.',
-                            required=False, action="store", default=",")
-        parser.add_argument("--convert_gps_time",
-                            help="Convert gps time in ticks to standard time.", action="store_true", default=False, required=False)
-        parser.add_argument("--convert_utc_time",
-                            help="Convert utc epoch time in seconds or milliseconds.", action="store_true", default=False, required=False)
-        parser.add_argument("--filename_column",
-                            help='Specify the column number of image filename, counting from 1 on.', action="store", required=False, type=int)
-        parser.add_argument("--timestamp_column",
-                            help='Specify the column number of image timestamp, counting from 1 on.', action="store", required=False, type=int)
-        parser.add_argument("--latitude_column",
-                            help='Specify the column number of image latitude, counting from 1 on.', action="store", required=False, type=int)
-        parser.add_argument("--longitude_column",
-                            help='Specify the column number of image longitude, counting from 1 on.', action="store", required=False, type=int)
-        parser.add_argument("--heading_column",
-                            help='Specify the column number of image heading, counting from 1 on.', action="store", required=False, type=int)
-        parser.add_argument("--altitude_column",
-                            help='Specify the column number of image altitude, counting from 1 on.', action="store", required=False, type=int)
-        parser.add_argument("--gps_week_column",
-                            help='Specify the column number of image timestamps gps week, counting from 1 on. Used only with --convert_gps_time.', action="store", required=False, type=int)
-        parser.add_argument("--meta_columns",
-                            help='Specify the column numbers containing meta data, separate numbers with commas, example "7,9,10".', action="store", default=None, required=False)
-        parser.add_argument("--meta_names",
-                            help='Specify the meta data names, separate names with commas, example "meta_data_1,meta_data2,meta_data3".', action="store", default=None, required=False)
-        parser.add_argument("--meta_types",
-                            help='Specify the meta data types, separate types with commas, example "string,string,long". Available types are [string, double, long, date, boolean]', action="store", default=None, required=False)
-        parser.add_argument("--time_format",
-                            help='Specify the format of the date/time.', action="store", default="%Y:%m:%d %H:%M:%S.%f", required=False)
-        parser.add_argument('--header', help="The csv file includes a header.",
-                            default=False, required=False, action='store_true')
+        add_process_csv_basic_arguments(parser)
 
     def add_advanced_arguments(self, parser):
-        parser.add_argument('--keep_original', help='Do not overwrite original images, instead save the processed images in a new directory by adding suffix "_processed" to the import_path.',
-                            action='store_true', default=False, required=False)
+        add_process_csv_advanced_arguments(parser)
 
     def run(self, args):
 

--- a/mapillary_tools/commands/sample_video.py
+++ b/mapillary_tools/commands/sample_video.py
@@ -16,8 +16,6 @@ class Command:
                             help="Real time video duration ratio of the under or oversampled video duration.", type=float, default=1.0, required=False)
         parser.add_argument("--video_start_time", help="Video start time in epochs (milliseconds)",
                             type=int, default=None, required=False)
-        parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
 
     def add_advanced_arguments(self, parser):
         pass

--- a/mapillary_tools/commands/sample_video.py
+++ b/mapillary_tools/commands/sample_video.py
@@ -1,5 +1,7 @@
 
-from mapillary_tools.process_video import sample_video
+from mapillary_tools.process_video import (
+    add_video_arguments,
+    sample_video)
 
 
 class Command:
@@ -7,15 +9,7 @@ class Command:
     help = "Main tool : Sample video into images."
 
     def add_basic_arguments(self, parser):
-        # video specific args
-        parser.add_argument('--video_import_path', help='Path to a video or directory with one or more video files.',
-                            action='store', required=True)
-        parser.add_argument('--video_sample_interval',
-                            help='Time interval for sampled video frames in seconds', default=2, type=float, required=False)
-        parser.add_argument("--video_duration_ratio",
-                            help="Real time video duration ratio of the under or oversampled video duration.", type=float, default=1.0, required=False)
-        parser.add_argument("--video_start_time", help="Video start time in epochs (milliseconds)",
-                            type=int, default=None, required=False)
+        add_video_arguments(parser)
 
     def add_advanced_arguments(self, parser):
         pass

--- a/mapillary_tools/commands/send_videos_for_processing.py
+++ b/mapillary_tools/commands/send_videos_for_processing.py
@@ -1,6 +1,7 @@
 from mapillary_tools.process_user_properties import (
     add_organization_arguments,
     add_mapillary_arguments)
+from mapillary_tools.edit_config import add_user_auth_arguments
 from mapillary_tools.uploader import send_videos_for_processing
 import inspect
 
@@ -10,19 +11,9 @@ class Command:
     help = "Helper tool : Send videos for processing at Mapillary."
 
     def add_basic_arguments(self, parser):
-        parser.add_argument(
-            "--user_name", help="Mapillary user name", required=True)
-        parser.add_argument(
-            "--user_email", help="user email, used to create Mapillary account", default=None, required=False)
-        parser.add_argument(
-            "--user_password", help="password associated with the Mapillary user account", default=None, required=False)
-        parser.add_argument(
-            '--user_key', help='Manually specify user key', default=False, required=False)
-        parser.add_argument(
-            '--api_version', help='Choose which Mapillary API version to use', default=1.0, required=False)
-# consider having api version as string
-        parser.add_argument(
-            '--video_import_path', help='Path to a video or a directory with one or more video files.', action='store', required=True)
+        add_user_auth_arguments(parser, has_jwt=False)
+        parser.add_argument('--video_import_path', help='Path to a video or a directory with one or more video files.',
+                            action='store', required=True)
         add_organization_arguments(parser)
         parser.add_argument(
             '--sampling_distance', help="Specify distance between images to be used when sampling video", default=2, required=False)

--- a/mapillary_tools/commands/send_videos_for_processing.py
+++ b/mapillary_tools/commands/send_videos_for_processing.py
@@ -1,3 +1,6 @@
+from mapillary_tools.process_user_properties import (
+    add_organization_arguments,
+    add_mapillary_arguments)
 from mapillary_tools.uploader import send_videos_for_processing
 import inspect
 
@@ -20,12 +23,7 @@ class Command:
 # consider having api version as string
         parser.add_argument(
             '--video_import_path', help='Path to a video or a directory with one or more video files.', action='store', required=True)
-        parser.add_argument(
-            '--organization_username', help="Specify organization user name", default=None, required=False)
-        parser.add_argument(
-            '--organization_key', help="Specify organization key", default=None, required=False)
-        parser.add_argument(
-            '--private', help="Specify whether the import is private", action='store_true', default=False, required=False)
+        add_organization_arguments(parser)
         parser.add_argument(
             '--sampling_distance', help="Specify distance between images to be used when sampling video", default=2, required=False)
         parser.add_argument(
@@ -34,11 +32,10 @@ class Command:
             '--orientation', help='Specify the image orientation in degrees. ', choices=[0, 90, 180, 270], type=int, default=0, required=False)
         
     def add_advanced_arguments(self, parser):
-        parser.add_argument(
-            "--master_upload", help="Uploading on behalf of someone else. Specify end user account where images must be assigned. Internal user only", default=None, required=False)
+        add_mapillary_arguments(parser)
         parser.add_argument(
             '--filter_night_time', help="Unsupported feature. Filter images taken between sunset and sunrise", action='store_true', default=False, required=False)
-        
+
     def run(self, args):
         vars_args = vars(args)
         send_videos_for_processing(

--- a/mapillary_tools/commands/send_videos_for_processing.py
+++ b/mapillary_tools/commands/send_videos_for_processing.py
@@ -12,20 +12,25 @@ class Command:
 
     def add_basic_arguments(self, parser):
         add_user_auth_arguments(parser, has_jwt=False)
-        parser.add_argument('--video_import_path', help='Path to a video or a directory with one or more video files.',
-                            action='store', required=True)
+        parser.add_argument('--video_import_path',
+            help="Path to a video or a directory with one or more video files.",
+            action='store', required=True)
         add_organization_arguments(parser)
-        parser.add_argument(
-            '--sampling_distance', help="Specify distance between images to be used when sampling video", default=2, required=False)
-        parser.add_argument(
-            '--offset_angle', help="offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing)", default=0, required=False)
-        parser.add_argument(
-            '--orientation', help='Specify the image orientation in degrees. ', choices=[0, 90, 180, 270], type=int, default=0, required=False)
-        
+        parser.add_argument('--sampling_distance',
+            help="Specify distance between images to be used when sampling video",
+            default=2, required=False)
+        parser.add_argument('--offset_angle',
+            help="offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing)",
+            default=0, required=False)
+        parser.add_argument('--orientation',
+            help="Specify the image orientation in degrees.",
+            choices=[0, 90, 180, 270], type=int, default=0, required=False)
+
     def add_advanced_arguments(self, parser):
         add_mapillary_arguments(parser)
-        parser.add_argument(
-            '--filter_night_time', help="Unsupported feature. Filter images taken between sunset and sunrise", action='store_true', default=False, required=False)
+        parser.add_argument('--filter_night_time',
+            help='Unsupported feature. Filter images taken between sunset and sunrise.',
+            action='store_true', default=False, required=False)
 
     def run(self, args):
         vars_args = vars(args)

--- a/mapillary_tools/commands/send_videos_for_processing.py
+++ b/mapillary_tools/commands/send_videos_for_processing.py
@@ -19,8 +19,6 @@ class Command:
             '--api_version', help='Choose which Mapillary API version to use', default=1.0, required=False)
 # consider having api version as string
         parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the videos in the given directory path.', action='store_true', default=False, required=False)
-        parser.add_argument(
             '--video_import_path', help='Path to a video or a directory with one or more video files.', action='store', required=True)
         parser.add_argument(
             '--organization_username', help="Specify organization user name", default=None, required=False)

--- a/mapillary_tools/commands/send_videos_for_processing.py
+++ b/mapillary_tools/commands/send_videos_for_processing.py
@@ -12,14 +12,14 @@ class Command:
 
     def add_basic_arguments(self, parser):
         add_user_auth_arguments(parser, has_jwt=False)
-        parser.add_argument('--video_import_path',
+        parser.add_argument('--video-import-path', '--video_import_path',
             help="Path to a video or a directory with one or more video files.",
             action='store', required=True)
         add_organization_arguments(parser)
-        parser.add_argument('--sampling_distance',
+        parser.add_argument('--sampling-distance', '--sampling_distance',
             help="Specify distance between images to be used when sampling video",
             default=2, required=False)
-        parser.add_argument('--offset_angle',
+        parser.add_argument('--offset-angle', '--offset_angle',
             help="offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing)",
             default=0, required=False)
         parser.add_argument('--orientation',
@@ -28,7 +28,7 @@ class Command:
 
     def add_advanced_arguments(self, parser):
         add_mapillary_arguments(parser)
-        parser.add_argument('--filter_night_time',
+        parser.add_argument('--filter-night-time', '--filter_night_time',
             help='Unsupported feature. Filter images taken between sunset and sunrise.',
             action='store_true', default=False, required=False)
 

--- a/mapillary_tools/commands/upload.py
+++ b/mapillary_tools/commands/upload.py
@@ -8,10 +8,7 @@ class Command:
     help = "Main tool : Upload images to Mapillary."
 
     def add_basic_arguments(self, parser):
-
-        # command specific args
-        parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
+        pass
 
     def add_advanced_arguments(self, parser):
         parser.add_argument(

--- a/mapillary_tools/commands/upload.py
+++ b/mapillary_tools/commands/upload.py
@@ -3,7 +3,9 @@ from mapillary_tools.upload import (
     add_upload_arguments,
     add_dry_run_arguments,
     upload)
-from mapillary_tools.post_process import post_process
+from mapillary_tools.post_process import (
+    add_post_process_arguments,
+    post_process)
 
 
 class Command:
@@ -16,26 +18,7 @@ class Command:
     def add_advanced_arguments(self, parser):
         add_upload_arguments(parser)
         add_dry_run_arguments(parser)
-
-        # post process
-        parser.add_argument('--summarize', help='Summarize import for given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_all_images', help='Move all images in import_path according to import state.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_duplicates', help='Move images in case they were flagged as duplicates.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_uploaded', help='Move images according to upload state.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_sequences', help='Move images into sequence folders.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--save_as_json', help='Save summary or file status list in a json.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--list_file_status', help='List file status for given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--push_images', help='Push images uploaded in given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--save_local_mapping', help='Save the mapillary photo uuid to local file mapping in a csv.',
-                            action='store_true', default=False, required=False)
+        add_post_process_arguments(parser)
 
     def run(self, args):
 

--- a/mapillary_tools/commands/upload.py
+++ b/mapillary_tools/commands/upload.py
@@ -1,5 +1,8 @@
 import inspect
-from mapillary_tools.upload import upload
+from mapillary_tools.upload import (
+    add_upload_arguments,
+    add_dry_run_arguments,
+    upload)
 from mapillary_tools.post_process import post_process
 
 
@@ -11,13 +14,8 @@ class Command:
         pass
 
     def add_advanced_arguments(self, parser):
-        parser.add_argument(
-            '--number_threads', help='Specify the number of upload threads.', type=int, default=None, required=False)
-        parser.add_argument(
-            '--max_attempts', help='Specify the maximum number of attempts to upload.', type=int, default=None, required=False)
-        parser.add_argument(
-            '--dry_run', help='Disable actual upload. Used for debugging only',type=bool, default=False, required=False)
-        
+        add_upload_arguments(parser)
+        add_dry_run_arguments(parser)
 
         # post process
         parser.add_argument('--summarize', help='Summarize import for given import path.',

--- a/mapillary_tools/commands/video_process.py
+++ b/mapillary_tools/commands/video_process.py
@@ -1,5 +1,9 @@
 import inspect
-from mapillary_tools.process_user_properties import process_user_properties
+from mapillary_tools.process_user_properties import (
+    add_user_arguments,
+    add_organization_arguments,
+    add_mapillary_arguments,
+    process_user_properties)
 from mapillary_tools.process_import_meta_properties import process_import_meta_properties
 from mapillary_tools.process_geotag_properties import process_geotag_properties
 from mapillary_tools.process_sequence_properties import process_sequence_properties
@@ -15,16 +19,8 @@ class Command:
     help = "Batch tool : Sample video into images and process image meta data and insert it in image EXIF ImageDescription."
 
     def add_basic_arguments(self, parser):
-        # user properties
-        # user name for the import
-        parser.add_argument("--user_name", help="user name", required=True)
-        # organization level parameters
-        parser.add_argument(
-            '--organization_username', help="Specify organization user name", default=None, required=False)
-        parser.add_argument(
-            '--organization_key', help="Specify organization key", default=None, required=False)
-        parser.add_argument('--private',
-                            help="Specify whether the import is private", action='store_true', default=False, required=False)
+        add_user_arguments(parser)
+        add_organization_arguments(parser)
 
         # video specific args
         parser.add_argument('--video_import_path', help='Path to a video or a directory with one or more video files.',
@@ -37,9 +33,8 @@ class Command:
                             type=int, default=None, required=False)
 
     def add_advanced_arguments(self, parser):
-        # master upload
-        parser.add_argument('--master_upload', help='Process images with a master key, note: only used by Mapillary employees',
-                            action='store_true', default=False, required=False)
+        add_mapillary_arguments(parser)
+
         #import meta
         parser.add_argument(
             "--device_make", help="Specify device manufacturer. Note this input has precedence over the input read from the import source file.", default=None, required=False)

--- a/mapillary_tools/commands/video_process.py
+++ b/mapillary_tools/commands/video_process.py
@@ -10,7 +10,9 @@ from mapillary_tools.process_import_meta_properties import (
 from mapillary_tools.process_geotag_properties import (
     add_geotag_arguments,
     process_geotag_properties)
-from mapillary_tools.process_sequence_properties import process_sequence_properties
+from mapillary_tools.process_sequence_properties import (
+    add_sequence_arguments,
+    process_sequence_properties)
 from mapillary_tools.process_upload_params import process_upload_params
 from mapillary_tools.insert_MAPJson import insert_MAPJson
 from mapillary_tools.process_video import (
@@ -33,20 +35,8 @@ class Command:
         add_mapillary_arguments(parser)
         add_import_meta_arguments(parser)
         add_geotag_arguments(parser)
+        add_sequence_arguments(parser)
 
-        # sequence
-        parser.add_argument('--cutoff_distance', default=600., type=float,
-                            help='maximum gps distance in meters within a sequence', required=False)
-        parser.add_argument('--cutoff_time', default=60., type=float,
-                            help='maximum time interval in seconds within a sequence', required=False)
-        parser.add_argument('--interpolate_directions',
-                            help='perform interpolation of directions', action='store_true', required=False)
-        parser.add_argument('--keep_duplicates',
-                            help='keep duplicates, ie do not flag duplicates for upload exclusion, but keep them to be uploaded', action='store_true', required=False, default=False)
-        parser.add_argument('--duplicate_distance',
-                            help='max distance for two images to be considered duplicates in meters', type=float, default=0.1, required=False)
-        parser.add_argument(
-            '--duplicate_angle', help='max angle for two images to be considered duplicates in degrees', type=float, default=5, required=False)
         # EXIF insert
         parser.add_argument('--skip_EXIF_insert', help='Skip inserting the extracted data into image EXIF.',
                             action='store_true', default=False, required=False)

--- a/mapillary_tools/commands/video_process.py
+++ b/mapillary_tools/commands/video_process.py
@@ -14,7 +14,9 @@ from mapillary_tools.process_sequence_properties import (
     add_sequence_arguments,
     process_sequence_properties)
 from mapillary_tools.process_upload_params import process_upload_params
-from mapillary_tools.insert_MAPJson import insert_MAPJson
+from mapillary_tools.insert_MAPJson import (
+    add_EXIF_insert_arguments,
+    insert_MAPJson)
 from mapillary_tools.process_video import (
     add_video_arguments,
     sample_video)
@@ -36,22 +38,8 @@ class Command:
         add_import_meta_arguments(parser)
         add_geotag_arguments(parser)
         add_sequence_arguments(parser)
+        add_EXIF_insert_arguments(parser)
 
-        # EXIF insert
-        parser.add_argument('--skip_EXIF_insert', help='Skip inserting the extracted data into image EXIF.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--keep_original', help='Do not overwrite original images, instead save the processed images in a new directory called "processed_images" located in .mapillary in the import_path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_all_EXIF_tags', help='Overwrite the rest of the EXIF tags, whose values are changed during the processing. Default is False, which will result in the processed values to be inserted only in the EXIF Image Description tag.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_time_tag', help='Overwrite the capture time EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_gps_tag', help='Overwrite the gps EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_direction_tag', help='Overwrite the camera direction EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_orientation_tag', help='Overwrite the orientation EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
         # post process
         parser.add_argument('--summarize', help='Summarize import for given import path.',
                             action='store_true', default=False, required=False)

--- a/mapillary_tools/commands/video_process.py
+++ b/mapillary_tools/commands/video_process.py
@@ -15,8 +15,6 @@ class Command:
     help = "Batch tool : Sample video into images and process image meta data and insert it in image EXIF ImageDescription."
 
     def add_basic_arguments(self, parser):
-        parser.add_argument(
-            '--rerun', help='rerun the processing', action='store_true', required=False)
         # user properties
         # user name for the import
         parser.add_argument("--user_name", help="user name", required=True)
@@ -27,8 +25,7 @@ class Command:
             '--organization_key', help="Specify organization key", default=None, required=False)
         parser.add_argument('--private',
                             help="Specify whether the import is private", action='store_true', default=False, required=False)
-        parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
+
         # video specific args
         parser.add_argument('--video_import_path', help='Path to a video or a directory with one or more video files.',
                             action='store', default=None, required=False)

--- a/mapillary_tools/commands/video_process.py
+++ b/mapillary_tools/commands/video_process.py
@@ -20,7 +20,9 @@ from mapillary_tools.insert_MAPJson import (
 from mapillary_tools.process_video import (
     add_video_arguments,
     sample_video)
-from mapillary_tools.post_process import post_process
+from mapillary_tools.post_process import (
+    add_post_process_arguments,
+    post_process)
 from mapillary_tools.apply_camera_specific_config import apply_camera_specific_config
 
 
@@ -39,28 +41,7 @@ class Command:
         add_geotag_arguments(parser)
         add_sequence_arguments(parser)
         add_EXIF_insert_arguments(parser)
-
-        # post process
-        parser.add_argument('--summarize', help='Summarize import for given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_all_images', help='Move all images in import_path according to import state.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_duplicates', help='Move images in case they were flagged as duplicates.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_uploaded', help='Move images according to upload state.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_sequences', help='Move images into sequence folders.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--save_as_json', help='Save summary or file status list in a json.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--list_file_status', help='List file status for given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--push_images', help='Push images uploaded in given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument(
-            '--split_import_path', help='If splitting the import path into duplicates, sequences, success and failed uploads, provide a path for the splits.', default=None, required=False)
-        parser.add_argument('--save_local_mapping', help='Save the mapillary photo uuid to local file mapping in a csv.',
-                            action='store_true', default=False, required=False)
+        add_post_process_arguments(parser)
 
     def run(self, args):
         vars_args = vars(args)

--- a/mapillary_tools/commands/video_process.py
+++ b/mapillary_tools/commands/video_process.py
@@ -7,7 +7,9 @@ from mapillary_tools.process_user_properties import (
 from mapillary_tools.process_import_meta_properties import (
     add_import_meta_arguments,
     process_import_meta_properties)
-from mapillary_tools.process_geotag_properties import process_geotag_properties
+from mapillary_tools.process_geotag_properties import (
+    add_geotag_arguments,
+    process_geotag_properties)
 from mapillary_tools.process_sequence_properties import process_sequence_properties
 from mapillary_tools.process_upload_params import process_upload_params
 from mapillary_tools.insert_MAPJson import insert_MAPJson
@@ -30,24 +32,7 @@ class Command:
     def add_advanced_arguments(self, parser):
         add_mapillary_arguments(parser)
         add_import_meta_arguments(parser)
-
-        # geotagging
-        parser.add_argument('--geotag_source', help='Provide the source of date/time and gps information needed for geotagging.', action='store',
-                            choices=['exif', 'gpx', 'gopro_videos', 'nmea', 'blackvue_videos'], default="exif", required=False)
-        parser.add_argument(
-            '--geotag_source_path', help='Provide the path to the file source of date/time and gps information needed for geotagging.', action='store',
-            default=None, required=False)
-        parser.add_argument(
-            '--local_time', help='Assume image timestamps are in your local time', action='store_true', default=False, required=False)
-        parser.add_argument('--sub_second_interval',
-                            help='Sub second time between shots. Used to set image times with sub-second precision',
-                            type=float, default=0.0, required=False)
-        parser.add_argument('--offset_time', default=0., type=float,
-                            help='time offset between the camera and the gps device, in seconds.', required=False)
-        parser.add_argument('--offset_angle', default=0., type=float,
-                            help='offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing)', required=False)
-        parser.add_argument("--use_gps_start_time",
-                            help="Use GPS trace starting time in case of derivating timestamp from filename.", action="store_true", default=False, required=False)
+        add_geotag_arguments(parser)
 
         # sequence
         parser.add_argument('--cutoff_distance', default=600., type=float,

--- a/mapillary_tools/commands/video_process.py
+++ b/mapillary_tools/commands/video_process.py
@@ -4,7 +4,9 @@ from mapillary_tools.process_user_properties import (
     add_organization_arguments,
     add_mapillary_arguments,
     process_user_properties)
-from mapillary_tools.process_import_meta_properties import process_import_meta_properties
+from mapillary_tools.process_import_meta_properties import (
+    add_import_meta_arguments,
+    process_import_meta_properties)
 from mapillary_tools.process_geotag_properties import process_geotag_properties
 from mapillary_tools.process_sequence_properties import process_sequence_properties
 from mapillary_tools.process_upload_params import process_upload_params
@@ -27,28 +29,7 @@ class Command:
 
     def add_advanced_arguments(self, parser):
         add_mapillary_arguments(parser)
-
-        #import meta
-        parser.add_argument(
-            "--device_make", help="Specify device manufacturer. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            "--device_model", help="Specify device model. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            '--add_file_name', help="Add original file name to EXIF. Note this input has precedence over the input read from the import source file.", action='store_true', required=False)
-        parser.add_argument(
-            '--exclude_import_path', help="If local file name is to be added exclude import_path from the name.", action='store_true', required=False)
-        parser.add_argument(
-            "--exclude_path", help="If local file name is to be added, specify the path to be excluded.", default=None, required=False)
-        parser.add_argument(
-            '--windows_path', help="If local file name is to be added with --add_file_name, added it as a windows path.", action='store_true', required=False)
-        parser.add_argument(
-            '--add_import_date', help="Add import date.", action='store_true', required=False)
-        parser.add_argument('--orientation', help='Specify the image orientation in degrees. Note this might result in image rotation. Note this input has precedence over the input read from the import source file.',
-                            choices=[0, 90, 180, 270], type=int, default=None, required=False)
-        parser.add_argument(
-            "--GPS_accuracy", help="GPS accuracy in meters. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            "--camera_uuid", help="Custom string used to differentiate different captures taken with the same camera make and model.", default=None, required=False)
+        add_import_meta_arguments(parser)
 
         # geotagging
         parser.add_argument('--geotag_source', help='Provide the source of date/time and gps information needed for geotagging.', action='store',
@@ -117,11 +98,6 @@ class Command:
             '--split_import_path', help='If splitting the import path into duplicates, sequences, success and failed uploads, provide a path for the splits.', default=None, required=False)
         parser.add_argument('--save_local_mapping', help='Save the mapillary photo uuid to local file mapping in a csv.',
                             action='store_true', default=False, required=False)
-
-        # add custom meta data in a form of a string consisting of a triplet
-        # "name,type,value"
-        parser.add_argument('--custom_meta_data', help='Add custom meta data to all images. Required format of input is a string, consisting of the meta data name, type and value, separated by a comma for each entry, where entries are separated by semicolon. Supported types are long, double, string, boolean, date. Example for two meta data entries "random_name1,double,12.34;random_name2,long,1234"',
-                            default=None, required=False)
 
     def run(self, args):
         vars_args = vars(args)

--- a/mapillary_tools/commands/video_process.py
+++ b/mapillary_tools/commands/video_process.py
@@ -9,7 +9,9 @@ from mapillary_tools.process_geotag_properties import process_geotag_properties
 from mapillary_tools.process_sequence_properties import process_sequence_properties
 from mapillary_tools.process_upload_params import process_upload_params
 from mapillary_tools.insert_MAPJson import insert_MAPJson
-from mapillary_tools.process_video import sample_video
+from mapillary_tools.process_video import (
+    add_video_arguments,
+    sample_video)
 from mapillary_tools.post_process import post_process
 from mapillary_tools.apply_camera_specific_config import apply_camera_specific_config
 
@@ -21,16 +23,7 @@ class Command:
     def add_basic_arguments(self, parser):
         add_user_arguments(parser)
         add_organization_arguments(parser)
-
-        # video specific args
-        parser.add_argument('--video_import_path', help='Path to a video or a directory with one or more video files.',
-                            action='store', default=None, required=False)
-        parser.add_argument('--video_sample_interval',
-                            help='Time interval for sampled video frames in seconds', default=2, type=float, required=False)
-        parser.add_argument("--video_duration_ratio",
-                            help="Real time video duration ratio of the under or oversampled video duration.", type=float, default=1.0, required=False)
-        parser.add_argument("--video_start_time", help="Video start time in epochs (milliseconds)",
-                            type=int, default=None, required=False)
+        add_video_arguments(parser)
 
     def add_advanced_arguments(self, parser):
         add_mapillary_arguments(parser)

--- a/mapillary_tools/commands/video_process_and_upload.py
+++ b/mapillary_tools/commands/video_process_and_upload.py
@@ -4,7 +4,9 @@ from mapillary_tools.process_user_properties import (
     add_organization_arguments,
     add_mapillary_arguments,
     process_user_properties)
-from mapillary_tools.process_import_meta_properties import process_import_meta_properties
+from mapillary_tools.process_import_meta_properties import (
+    add_import_meta_arguments,
+    process_import_meta_properties)
 from mapillary_tools.process_geotag_properties import process_geotag_properties
 from mapillary_tools.process_sequence_properties import process_sequence_properties
 from mapillary_tools.process_upload_params import process_upload_params
@@ -27,28 +29,7 @@ class Command:
 
     def add_advanced_arguments(self, parser):
         add_mapillary_arguments(parser)
-
-        #import meta
-        parser.add_argument(
-            "--device_make", help="Specify device manufacturer. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            "--device_model", help="Specify device model. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            '--add_file_name', help="Add original file name to EXIF. Note this input has precedence over the input read from the import source file.", action='store_true', required=False)
-        parser.add_argument(
-            '--exclude_import_path', help="If local file name is to be added exclude import_path from the name.", action='store_true', required=False)
-        parser.add_argument(
-            "--exclude_path", help="If local file name is to be added, specify the path to be excluded.", default=None, required=False)
-        parser.add_argument(
-            '--windows_path', help="If local file name is to be added with --add_file_name, added it as a windows path.", action='store_true', required=False)
-        parser.add_argument(
-            '--add_import_date', help="Add import date.", action='store_true', required=False)
-        parser.add_argument('--orientation', help='Specify the image orientation in degrees. Note this might result in image rotation. Note this input has precedence over the input read from the import source file.',
-                            choices=[0, 90, 180, 270], type=int, default=None, required=False)
-        parser.add_argument(
-            "--GPS_accuracy", help="GPS accuracy in meters. Note this input has precedence over the input read from the import source file.", default=None, required=False)
-        parser.add_argument(
-            "--camera_uuid", help="Custom string used to differentiate different captures taken with the same camera make and model.", default=None, required=False)
+        add_import_meta_arguments(parser)
 
         # geotagging
         parser.add_argument('--geotag_source', help='Provide the source of date/time and gps information needed for geotagging.', action='store',
@@ -121,11 +102,6 @@ class Command:
             '--split_import_path', help='If splitting the import path into duplicates, sequences, success and failed uploads, provide a path for the splits.', default=None, required=False)
         parser.add_argument('--save_local_mapping', help='Save the mapillary photo uuid to local file mapping in a csv.',
                             action='store_true', default=False, required=False)
-
-        # add custom meta data in a form of a string consisting of a triplet
-        # "name,type,value"
-        parser.add_argument('--custom_meta_data', help='Add custom meta data to all images. Required format of input is a string, consisting of the meta data name, type and value, separated by a comma for each entry, where entries are separated by semicolon. Supported types are long, double, string, boolean, date. Example for two meta data entries "random_name1,double,12.34;random_name2,long,1234"',
-                            default=None, required=False)
 
     def run(self, args):
 

--- a/mapillary_tools/commands/video_process_and_upload.py
+++ b/mapillary_tools/commands/video_process_and_upload.py
@@ -23,7 +23,9 @@ from mapillary_tools.process_video import (
 from mapillary_tools.upload import (
     add_upload_arguments,
     upload)
-from mapillary_tools.post_process import post_process
+from mapillary_tools.post_process import (
+    add_post_process_arguments,
+    post_process)
 
 
 class Command:
@@ -42,28 +44,7 @@ class Command:
         add_sequence_arguments(parser)
         add_EXIF_insert_arguments(parser)
         add_upload_arguments(parser)
-
-        # post process
-        parser.add_argument('--summarize', help='Summarize import for given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_all_images', help='Move all images in import_path according to import state.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_duplicates', help='Move images in case they were flagged as duplicates.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_uploaded', help='Move images according to upload state.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--move_sequences', help='Move images into sequence folders.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--save_as_json', help='Save summary or file status list in a json.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--list_file_status', help='List file status for given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--push_images', help='Push images uploaded in given import path.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument(
-            '--split_import_path', help='If splitting the import path into duplicates, sequences, success and failed uploads, provide a path for the splits.', default=None, required=False)
-        parser.add_argument('--save_local_mapping', help='Save the mapillary photo uuid to local file mapping in a csv.',
-                            action='store_true', default=False, required=False)
+        add_post_process_arguments(parser)
 
     def run(self, args):
 

--- a/mapillary_tools/commands/video_process_and_upload.py
+++ b/mapillary_tools/commands/video_process_and_upload.py
@@ -15,8 +15,6 @@ class Command:
     help = "Batch tool : Sample video into images, process images and upload to Mapillary."
 
     def add_basic_arguments(self, parser):
-        parser.add_argument(
-            '--rerun', help='rerun the processing', action='store_true', required=False)
         # user properties
         # user name for the import
         parser.add_argument("--user_name", help="user name", required=True)
@@ -36,8 +34,6 @@ class Command:
                             help="Real time video duration ratio of the under or oversampled video duration.", type=float, default=1.0, required=False)
         parser.add_argument("--video_start_time", help="Video start time in epochs (milliseconds)",
                             type=int, default=None, required=False)
-        parser.add_argument(
-            '--skip_subfolders', help='Skip all subfolders and import only the images in the given directory path.', action='store_true', default=False, required=False)
 
     def add_advanced_arguments(self, parser):
         # master upload

--- a/mapillary_tools/commands/video_process_and_upload.py
+++ b/mapillary_tools/commands/video_process_and_upload.py
@@ -20,7 +20,9 @@ from mapillary_tools.insert_MAPJson import (
 from mapillary_tools.process_video import (
     add_video_arguments,
     sample_video)
-from mapillary_tools.upload import upload
+from mapillary_tools.upload import (
+    add_upload_arguments,
+    upload)
 from mapillary_tools.post_process import post_process
 
 
@@ -39,11 +41,7 @@ class Command:
         add_geotag_arguments(parser)
         add_sequence_arguments(parser)
         add_EXIF_insert_arguments(parser)
-
-        parser.add_argument(
-            '--number_threads', help='Specify the number of upload threads.', type=int, default=None, required=False)
-        parser.add_argument(
-            '--max_attempts', help='Specify the maximum number of attempts to upload.', type=int, default=None, required=False)
+        add_upload_arguments(parser)
 
         # post process
         parser.add_argument('--summarize', help='Summarize import for given import path.',

--- a/mapillary_tools/commands/video_process_and_upload.py
+++ b/mapillary_tools/commands/video_process_and_upload.py
@@ -14,7 +14,9 @@ from mapillary_tools.process_sequence_properties import (
     add_sequence_arguments,
     process_sequence_properties)
 from mapillary_tools.process_upload_params import process_upload_params
-from mapillary_tools.insert_MAPJson import insert_MAPJson
+from mapillary_tools.insert_MAPJson import (
+    add_EXIF_insert_arguments,
+    insert_MAPJson)
 from mapillary_tools.process_video import (
     add_video_arguments,
     sample_video)
@@ -36,26 +38,13 @@ class Command:
         add_import_meta_arguments(parser)
         add_geotag_arguments(parser)
         add_sequence_arguments(parser)
+        add_EXIF_insert_arguments(parser)
 
-        # EXIF insert
-        parser.add_argument('--skip_EXIF_insert', help='Skip inserting the extracted data into image EXIF.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--keep_original', help='Do not overwrite original images, instead save the processed images in a new directory called "processed_images" located in .mapillary in the import_path.',
-                            action='store_true', default=False, required=False)
         parser.add_argument(
             '--number_threads', help='Specify the number of upload threads.', type=int, default=None, required=False)
         parser.add_argument(
             '--max_attempts', help='Specify the maximum number of attempts to upload.', type=int, default=None, required=False)
-        parser.add_argument('--overwrite_all_EXIF_tags', help='Overwrite the rest of the EXIF tags, whose values are changed during the processing. Default is False, which will result in the processed values to be inserted only in the EXIF Image Description tag.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_time_tag', help='Overwrite the capture time EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_gps_tag', help='Overwrite the gps EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_direction_tag', help='Overwrite the camera direction EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
-        parser.add_argument('--overwrite_EXIF_orientation_tag', help='Overwrite the orientation EXIF tag with the value obtained in process.',
-                            action='store_true', default=False, required=False)
+
         # post process
         parser.add_argument('--summarize', help='Summarize import for given import path.',
                             action='store_true', default=False, required=False)

--- a/mapillary_tools/commands/video_process_and_upload.py
+++ b/mapillary_tools/commands/video_process_and_upload.py
@@ -10,7 +10,9 @@ from mapillary_tools.process_import_meta_properties import (
 from mapillary_tools.process_geotag_properties import (
     add_geotag_arguments,
     process_geotag_properties)
-from mapillary_tools.process_sequence_properties import process_sequence_properties
+from mapillary_tools.process_sequence_properties import (
+    add_sequence_arguments,
+    process_sequence_properties)
 from mapillary_tools.process_upload_params import process_upload_params
 from mapillary_tools.insert_MAPJson import insert_MAPJson
 from mapillary_tools.process_video import (
@@ -33,20 +35,8 @@ class Command:
         add_mapillary_arguments(parser)
         add_import_meta_arguments(parser)
         add_geotag_arguments(parser)
+        add_sequence_arguments(parser)
 
-        # sequence
-        parser.add_argument('--cutoff_distance', default=600., type=float,
-                            help='maximum gps distance in meters within a sequence', required=False)
-        parser.add_argument('--cutoff_time', default=60., type=float,
-                            help='maximum time interval in seconds within a sequence', required=False)
-        parser.add_argument('--interpolate_directions',
-                            help='perform interploation of directions', action='store_true', required=False)
-        parser.add_argument('--keep_duplicates',
-                            help='keep duplicates, ie do not flag duplicates for upload exclusion, but keep them to be uploaded', action='store_true', required=False, default=False)
-        parser.add_argument('--duplicate_distance',
-                            help='max distance for two images to be considered duplicates in meters', type=float, default=0.1, required=False)
-        parser.add_argument(
-            '--duplicate_angle', help='max angle for two images to be considered duplicates in degrees', type=float, default=5, required=False)
         # EXIF insert
         parser.add_argument('--skip_EXIF_insert', help='Skip inserting the extracted data into image EXIF.',
                             action='store_true', default=False, required=False)

--- a/mapillary_tools/commands/video_process_and_upload.py
+++ b/mapillary_tools/commands/video_process_and_upload.py
@@ -9,7 +9,9 @@ from mapillary_tools.process_geotag_properties import process_geotag_properties
 from mapillary_tools.process_sequence_properties import process_sequence_properties
 from mapillary_tools.process_upload_params import process_upload_params
 from mapillary_tools.insert_MAPJson import insert_MAPJson
-from mapillary_tools.process_video import sample_video
+from mapillary_tools.process_video import (
+    add_video_arguments,
+    sample_video)
 from mapillary_tools.upload import upload
 from mapillary_tools.post_process import post_process
 
@@ -21,16 +23,7 @@ class Command:
     def add_basic_arguments(self, parser):
         add_user_arguments(parser)
         add_organization_arguments(parser)
-
-        # video specific args
-        parser.add_argument('--video_import_path', help='Path to a video or a directory with one or more video files.',
-                            action='store', default=None, required=False)
-        parser.add_argument('--video_sample_interval',
-                            help='Time interval for sampled video frames in seconds', default=2, type=float, required=False)
-        parser.add_argument("--video_duration_ratio",
-                            help="Real time video duration ratio of the under or oversampled video duration.", type=float, default=1.0, required=False)
-        parser.add_argument("--video_start_time", help="Video start time in epochs (milliseconds)",
-                            type=int, default=None, required=False)
+        add_video_arguments(parser)
 
     def add_advanced_arguments(self, parser):
         add_mapillary_arguments(parser)

--- a/mapillary_tools/commands/video_process_and_upload.py
+++ b/mapillary_tools/commands/video_process_and_upload.py
@@ -1,5 +1,9 @@
 import inspect
-from mapillary_tools.process_user_properties import process_user_properties
+from mapillary_tools.process_user_properties import (
+    add_user_arguments,
+    add_organization_arguments,
+    add_mapillary_arguments,
+    process_user_properties)
 from mapillary_tools.process_import_meta_properties import process_import_meta_properties
 from mapillary_tools.process_geotag_properties import process_geotag_properties
 from mapillary_tools.process_sequence_properties import process_sequence_properties
@@ -15,16 +19,9 @@ class Command:
     help = "Batch tool : Sample video into images, process images and upload to Mapillary."
 
     def add_basic_arguments(self, parser):
-        # user properties
-        # user name for the import
-        parser.add_argument("--user_name", help="user name", required=True)
-        # organization level parameters
-        parser.add_argument(
-            '--organization_username', help="Specify organization user name", default=None, required=False)
-        parser.add_argument(
-            '--organization_key', help="Specify organization key", default=None, required=False)
-        parser.add_argument('--private',
-                            help="Specify whether the import is private", action='store_true', default=False, required=False)
+        add_user_arguments(parser)
+        add_organization_arguments(parser)
+
         # video specific args
         parser.add_argument('--video_import_path', help='Path to a video or a directory with one or more video files.',
                             action='store', default=None, required=False)
@@ -36,9 +33,8 @@ class Command:
                             type=int, default=None, required=False)
 
     def add_advanced_arguments(self, parser):
-        # master upload
-        parser.add_argument('--master_upload', help='Process images with a master key, note: only used by Mapillary employees',
-                            action='store_true', default=False, required=False)
+        add_mapillary_arguments(parser)
+
         #import meta
         parser.add_argument(
             "--device_make", help="Specify device manufacturer. Note this input has precedence over the input read from the import source file.", default=None, required=False)

--- a/mapillary_tools/commands/video_process_and_upload.py
+++ b/mapillary_tools/commands/video_process_and_upload.py
@@ -7,7 +7,9 @@ from mapillary_tools.process_user_properties import (
 from mapillary_tools.process_import_meta_properties import (
     add_import_meta_arguments,
     process_import_meta_properties)
-from mapillary_tools.process_geotag_properties import process_geotag_properties
+from mapillary_tools.process_geotag_properties import (
+    add_geotag_arguments,
+    process_geotag_properties)
 from mapillary_tools.process_sequence_properties import process_sequence_properties
 from mapillary_tools.process_upload_params import process_upload_params
 from mapillary_tools.insert_MAPJson import insert_MAPJson
@@ -30,24 +32,7 @@ class Command:
     def add_advanced_arguments(self, parser):
         add_mapillary_arguments(parser)
         add_import_meta_arguments(parser)
-
-        # geotagging
-        parser.add_argument('--geotag_source', help='Provide the source of date/time and gps information needed for geotagging.', action='store',
-                            choices=['exif', 'gpx', 'gopro_videos', 'nmea', 'blackvue_videos'], default="exif", required=False)
-        parser.add_argument(
-            '--geotag_source_path', help='Provide the path to the file source of date/time and gps information needed for geotagging.', action='store',
-            default=None, required=False)
-        parser.add_argument(
-            '--local_time', help='Assume image timestamps are in your local time', action='store_true', default=False, required=False)
-        parser.add_argument('--sub_second_interval',
-                            help='Sub second time between shots. Used to set image times with sub-second precision',
-                            type=float, default=0.0, required=False)
-        parser.add_argument('--offset_time', default=0., type=float,
-                            help='time offset between the camera and the gps device, in seconds.', required=False)
-        parser.add_argument('--offset_angle', default=0., type=float,
-                            help='offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing)', required=False)
-        parser.add_argument("--use_gps_start_time",
-                            help="Use GPS trace starting time in case of derivating timestamp from filename.", action="store_true", default=False, required=False)
+        add_geotag_arguments(parser)
 
         # sequence
         parser.add_argument('--cutoff_distance', default=600., type=float,

--- a/mapillary_tools/download.py
+++ b/mapillary_tools/download.py
@@ -122,12 +122,12 @@ def check_files_downloaded(local_mapping, output_folder, do_sleep):
         return True
 
 def add_download_basic_arguments(parser):
-    parser.add_argument('--output_folder',
+    parser.add_argument('--output-folder', '--output_folder',
         help='Output folder for the downloaded images.',
         required=True)
 
 def add_download_advanced_arguments(parser):
-    parser.add_argument('--number_threads',
+    parser.add_argument('--number-threads', '--number_threads',
         help='Specify the number of download threads.',
         type=int, default=10, required=False)
 

--- a/mapillary_tools/download.py
+++ b/mapillary_tools/download.py
@@ -121,6 +121,15 @@ def check_files_downloaded(local_mapping, output_folder, do_sleep):
         print("All files are downloaded")
         return True
 
+def add_download_basic_arguments(parser):
+    parser.add_argument('--output_folder',
+        help='Output folder for the downloaded images.',
+        required=True)
+
+def add_download_advanced_arguments(parser):
+    parser.add_argument('--number_threads',
+        help='Specify the number of download threads.',
+        type=int, default=10, required=False)
 
 def download(import_path, user_name, output_folder, number_threads=10, verbose=False):
     total_files = uploader.get_total_file_list(import_path)

--- a/mapillary_tools/edit_config.py
+++ b/mapillary_tools/edit_config.py
@@ -14,32 +14,32 @@ GLOBAL_CONFIG_FILEPATH = os.getenv(
 
 
 def add_user_auth_arguments(parser, has_jwt=True):
-    parser.add_argument('--user_name',
+    parser.add_argument('--user-name', '--user_name',
         help='Mapillary user name.',
         default=None, required=False)
-    parser.add_argument('--user_email',
+    parser.add_argument('--user-email', '--user_email',
         help='User email. Used to create the Mapillary account.',
         default=None, required=False)
-    parser.add_argument('--user_password',
+    parser.add_argument('--user-password', '--user_password',
         help='Password associated with the Mapillary user account.',
         default=None, required=False)
     if has_jwt:
         parser.add_argument('--jwt',
             help='JWT authentication token.',
             default=None, required=False)
-    parser.add_argument('--user_key',
+    parser.add_argument('--user-key', '--user_key',
         help='Manually specify user key.',
         default=False, required=False)
     # Consider having API version as a string
-    parser.add_argument('--api_version',
+    parser.add_argument('--api-version', '--api_version',
         help='Choose which Mapillary API version to use.',
         default=1.0, required=False)
 
 def add_edit_config_arguments(parser):
-    parser.add_argument('--config_file',
+    parser.add_argument('--config-file', '--config_file',
         help='Full path to the config file to be edited. Default is ~/.config/mapillary/config/MkJKbDA0bnZuZlcxeTJHTmFqN3g1dzo1YTM0NjRkM2EyZGU5MzBh',
         default=None, required=False)
-    parser.add_argument('--force_overwrite',
+    parser.add_argument('--force-overwrite', '--force_overwrite',
         help='Automatically overwrite any existing credentials stored in the config file for the specified user.',
         action='store_true', default=False, required=False)
 

--- a/mapillary_tools/edit_config.py
+++ b/mapillary_tools/edit_config.py
@@ -13,6 +13,36 @@ GLOBAL_CONFIG_FILEPATH = os.getenv(
     os.path.join(os.path.expanduser('~'), ".config", "mapillary", 'configs', CLIENT_ID))
 
 
+def add_user_auth_arguments(parser, has_jwt=True):
+    parser.add_argument('--user_name',
+        help='Mapillary user name.',
+        default=None, required=False)
+    parser.add_argument('--user_email',
+        help='User email. Used to create the Mapillary account.',
+        default=None, required=False)
+    parser.add_argument('--user_password',
+        help='Password associated with the Mapillary user account.',
+        default=None, required=False)
+    if has_jwt:
+        parser.add_argument('--jwt',
+            help='JWT authentication token.',
+            default=None, required=False)
+    parser.add_argument('--user_key',
+        help='Manually specify user key.',
+        default=False, required=False)
+    # Consider having API version as a string
+    parser.add_argument('--api_version',
+        help='Choose which Mapillary API version to use.',
+        default=1.0, required=False)
+
+def add_edit_config_arguments(parser):
+    parser.add_argument('--config_file',
+        help='Full path to the config file to be edited. Default is ~/.config/mapillary/config/MkJKbDA0bnZuZlcxeTJHTmFqN3g1dzo1YTM0NjRkM2EyZGU5MzBh',
+        default=None, required=False)
+    parser.add_argument('--force_overwrite',
+        help='Automatically overwrite any existing credentials stored in the config file for the specified user.',
+        action='store_true', default=False, required=False)
+
 def edit_config(config_file=None, user_name=None, user_email=None, user_password=None, jwt=None, force_overwrite=False, user_key=None,api_version=1.0, upload_type='Video'):
     config_file_path = config_file if config_file else GLOBAL_CONFIG_FILEPATH
 

--- a/mapillary_tools/insert_MAPJson.py
+++ b/mapillary_tools/insert_MAPJson.py
@@ -9,25 +9,25 @@ from tqdm import tqdm
 from .error import print_error
 
 def add_EXIF_insert_arguments(parser):
-    parser.add_argument('--skip_EXIF_insert',
+    parser.add_argument('--skip-EXIF-insert', '--skip_EXIF_insert',
         help='Skip inserting the extracted data into image EXIF.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--keep_original',
+    parser.add_argument('--keep-original', '--keep_original',
         help='Do not overwrite original images, instead save the processed images in a new directory called "processed_images" located in .mapillary in the import_path.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--overwrite_all_EXIF_tags',
+    parser.add_argument('--overwrite-all-EXIF-tags', '--overwrite_all_EXIF_tags',
         help='Overwrite the rest of the EXIF tags, whose values are changed during the processing. Default is False, which will result in the processed values to be inserted only in the EXIF Image Description tag.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--overwrite_EXIF_time_tag',
+    parser.add_argument('--overwrite-EXIF-time-tag', '--overwrite_EXIF_time_tag',
         help='Overwrite the capture time EXIF tag with the value obtained in process.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--overwrite_EXIF_gps_tag',
+    parser.add_argument('--overwrite-EXIF-gps-tag', '--overwrite_EXIF_gps_tag',
         help='Overwrite the gps EXIF tag with the value obtained in process.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--overwrite_EXIF_direction_tag',
+    parser.add_argument('--overwrite-EXIF-direction-tag', '--overwrite_EXIF_direction_tag',
         help='Overwrite the camera direction EXIF tag with the value obtained in process.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--overwrite_EXIF_orientation_tag',
+    parser.add_argument('--overwrite-EXIF-orientation-tag', '--overwrite_EXIF_orientation_tag',
         help='Overwrite the orientation EXIF tag with the value obtained in process.',
         action='store_true', default=False, required=False)
 

--- a/mapillary_tools/insert_MAPJson.py
+++ b/mapillary_tools/insert_MAPJson.py
@@ -8,6 +8,29 @@ from tqdm import tqdm
 
 from .error import print_error
 
+def add_EXIF_insert_arguments(parser):
+    parser.add_argument('--skip_EXIF_insert',
+        help='Skip inserting the extracted data into image EXIF.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--keep_original',
+        help='Do not overwrite original images, instead save the processed images in a new directory called "processed_images" located in .mapillary in the import_path.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--overwrite_all_EXIF_tags',
+        help='Overwrite the rest of the EXIF tags, whose values are changed during the processing. Default is False, which will result in the processed values to be inserted only in the EXIF Image Description tag.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--overwrite_EXIF_time_tag',
+        help='Overwrite the capture time EXIF tag with the value obtained in process.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--overwrite_EXIF_gps_tag',
+        help='Overwrite the gps EXIF tag with the value obtained in process.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--overwrite_EXIF_direction_tag',
+        help='Overwrite the camera direction EXIF tag with the value obtained in process.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--overwrite_EXIF_orientation_tag',
+        help='Overwrite the orientation EXIF tag with the value obtained in process.',
+        action='store_true', default=False, required=False)
+
 
 def insert_MAPJson(import_path,
                    master_upload=False,

--- a/mapillary_tools/interpolation.py
+++ b/mapillary_tools/interpolation.py
@@ -12,6 +12,39 @@ import datetime
 from tqdm import tqdm
 from .error import print_error
 
+def add_interpolation_arguments(parser):
+    parser.add_argument('--data',
+        help='Specify which data you want to interpolate.',
+        action='store', required=True,
+        choices=['missing_gps', 'identical_timestamps'])
+    parser.add_argument('--max_time_delta',
+        help='Maximum delta time in seconds, for an image with a timestamp out of scope to have missing gps extrapolated.',
+        type=float, default=1.0, required=False)
+    parser.add_argument('--file_in_path',
+        help='Input file path, in case the identical timestamps to be interpolated are in an external file.',
+        required=False)
+    parser.add_argument('--file_format',
+        help='Format of the input file, only csv supported for now.',
+        default='csv', required=False)
+    parser.add_argument('--time_column',
+        help='Column with the timestamps, in case interpolating missing timestamps in a csv file.',
+        type=int, default=0, required=False)
+    parser.add_argument('--delimiter',
+        help='Delimiter between the columns, in case interpolating missing timestamps in a csv file.',
+        default=',', required=False)
+    parser.add_argument('--time_utc',
+        help='Is the timestamp in utc',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--time_format',
+        help='Time format as a string.',
+        default='%Y-%m-%dT%H:%M:%SZ', required=False)
+    parser.add_argument('--header',
+        help='Specify whether the csv file includes a header, in case interpolating missing timestamps in a csv file.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--keep_original',
+        help='Do not overwrite original file, instead save the file with interpolated times in a new file by adding suffix "_processed" to the input file.',
+        action='store_true', default=False, required=False)
+
 
 EPOCH = datetime.datetime.utcfromtimestamp(0)
 

--- a/mapillary_tools/interpolation.py
+++ b/mapillary_tools/interpolation.py
@@ -17,31 +17,31 @@ def add_interpolation_arguments(parser):
         help='Specify which data you want to interpolate.',
         action='store', required=True,
         choices=['missing_gps', 'identical_timestamps'])
-    parser.add_argument('--max_time_delta',
+    parser.add_argument('--max-time-delta', '--max_time_delta',
         help='Maximum delta time in seconds, for an image with a timestamp out of scope to have missing gps extrapolated.',
         type=float, default=1.0, required=False)
-    parser.add_argument('--file_in_path',
+    parser.add_argument('--file-in-path', '--file_in_path',
         help='Input file path, in case the identical timestamps to be interpolated are in an external file.',
         required=False)
-    parser.add_argument('--file_format',
+    parser.add_argument('--file-format', '--file_format',
         help='Format of the input file, only csv supported for now.',
         default='csv', required=False)
-    parser.add_argument('--time_column',
+    parser.add_argument('--time-column', '--time_column',
         help='Column with the timestamps, in case interpolating missing timestamps in a csv file.',
         type=int, default=0, required=False)
     parser.add_argument('--delimiter',
         help='Delimiter between the columns, in case interpolating missing timestamps in a csv file.',
         default=',', required=False)
-    parser.add_argument('--time_utc',
+    parser.add_argument('--time-utc', '--time_utc',
         help='Is the timestamp in utc',
         action='store_true', default=False, required=False)
-    parser.add_argument('--time_format',
+    parser.add_argument('--time-format', '--time_format',
         help='Time format as a string.',
         default='%Y-%m-%dT%H:%M:%SZ', required=False)
     parser.add_argument('--header',
         help='Specify whether the csv file includes a header, in case interpolating missing timestamps in a csv file.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--keep_original',
+    parser.add_argument('--keep-original', '--keep_original',
         help='Do not overwrite original file, instead save the file with interpolated times in a new file by adding suffix "_processed" to the input file.',
         action='store_true', default=False, required=False)
 

--- a/mapillary_tools/post_process.py
+++ b/mapillary_tools/post_process.py
@@ -14,31 +14,31 @@ def add_post_process_arguments(parser):
     parser.add_argument('--summarize',
         help='Summarize import for given import path.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--move_all_images',
+    parser.add_argument('--move-all-images', '--move_all_images',
         help='Move all images in import_path according to import state.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--move_duplicates',
+    parser.add_argument('--move-duplicates', '--move_duplicates',
         help='Move images in case they were flagged as duplicates.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--move_uploaded',
+    parser.add_argument('--move-uploaded', '--move_uploaded',
         help='Move images according to upload state.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--move_sequences',
+    parser.add_argument('--move-sequences', '--move_sequences',
         help='Move images into sequence folders.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--save_as_json',
+    parser.add_argument('--save-as-json', '--save_as_json',
         help='Save summary or file status list in a json.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--list_file_status',
+    parser.add_argument('--list-file-status', '--list_file_status',
         help='List file status for given import path.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--push_images',
+    parser.add_argument('--push-images', '--push_images',
         help='Push images uploaded in given import path.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--split_import_path',
+    parser.add_argument('--split-import-path', '--split_import_path',
         help='If splitting the import path into duplicates, sequences, success and failed uploads, provide a path for the splits.',
         default=None, required=False)
-    parser.add_argument('--save_local_mapping',
+    parser.add_argument('--save-local-mapping', '--save_local_mapping',
         help='Save the mapillary photo uuid to local file mapping in a csv.',
         action='store_true', default=False, required=False)
 

--- a/mapillary_tools/post_process.py
+++ b/mapillary_tools/post_process.py
@@ -10,6 +10,39 @@ import exif_read
 from . import ipc
 
 
+def add_post_process_arguments(parser):
+    parser.add_argument('--summarize',
+        help='Summarize import for given import path.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--move_all_images',
+        help='Move all images in import_path according to import state.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--move_duplicates',
+        help='Move images in case they were flagged as duplicates.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--move_uploaded',
+        help='Move images according to upload state.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--move_sequences',
+        help='Move images into sequence folders.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--save_as_json',
+        help='Save summary or file status list in a json.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--list_file_status',
+        help='List file status for given import path.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--push_images',
+        help='Push images uploaded in given import path.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--split_import_path',
+        help='If splitting the import path into duplicates, sequences, success and failed uploads, provide a path for the splits.',
+        default=None, required=False)
+    parser.add_argument('--save_local_mapping',
+        help='Save the mapillary photo uuid to local file mapping in a csv.',
+        action='store_true', default=False, required=False)
+
+
 def map_images_to_sequences(destination_mapping, total_files):
     unique_sequence_uuids = []
     sequence_counter = 0

--- a/mapillary_tools/process_csv.py
+++ b/mapillary_tools/process_csv.py
@@ -184,49 +184,49 @@ def read_csv(csv_path, delimiter=",", header=False):
     return csv_data
 
 def add_process_csv_basic_arguments(parser):
-    parser.add_argument('--csv_path',
+    parser.add_argument('--csv-path', '--csv_path',
         help='Provide the path to the csv file.',
         action='store', required=True)
     parser.add_argument('--delimiter',
         help='Delimiter between the columns.',
         action='store', default=',', required=False)
-    parser.add_argument('--convert_gps_time',
+    parser.add_argument('--convert-gps-time', '--convert_gps_time',
         help='Convert gps time in ticks to standard time.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--convert_utc_time',
+    parser.add_argument('--convert-utc-time', '--convert_utc_time',
         help='Convert utc epoch time in seconds or milliseconds.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--filename_column',
+    parser.add_argument('--filename-column', '--filename_column',
         help='Specify the column number of image filename, counting from 1 on.',
         action='store', type=int, required=False)
-    parser.add_argument('--timestamp_column',
+    parser.add_argument('--timestamp-column', '--timestamp_column',
         help='Specify the column number of image timestamp, counting from 1 on.',
         action='store', type=int, required=False)
-    parser.add_argument('--latitude_column',
+    parser.add_argument('--latitude-column', '--latitude_column',
         help='Specify the column number of image latitude, counting from 1 on.',
         action='store', type=int, required=False)
-    parser.add_argument('--longitude_column',
+    parser.add_argument('--longitude-column', '--longitude_column',
         help='Specify the column number of image longitude, counting from 1 on.',
         action='store', type=int, required=False)
-    parser.add_argument('--heading_column',
+    parser.add_argument('--heading-column', '--heading_column',
         help='Specify the column number of image heading, counting from 1 on.',
         action='store', type=int, required=False)
-    parser.add_argument('--altitude_column',
+    parser.add_argument('--altitude-column', '--altitude_column',
         help='Specify the column number of image altitude, counting from 1 on.',
         action='store', type=int, required=False)
-    parser.add_argument('--gps_week_column',
-        help='Specify the column number of image timestamps gps week, counting from 1 on. Used only with --convert_gps_time.',
+    parser.add_argument('--gps-week-column', '--gps_week_column',
+        help='Specify the column number of image timestamps gps week, counting from 1 on. Used only with --convert-gps-time.',
         action='store', type=int, required=False)
-    parser.add_argument('--meta_columns',
+    parser.add_argument('--meta-columns', '--meta_columns',
         help='Specify the column numbers containing meta data, separate numbers with commas, example "7,9,10".',
         action='store', default=None, required=False)
-    parser.add_argument('--meta_names',
+    parser.add_argument('--meta-names', '--meta_names',
         help='Specify the meta data names, separate names with commas, example "meta_data_1,meta_data2,meta_data3".',
         action='store', default=None, required=False)
-    parser.add_argument('--meta_types',
+    parser.add_argument('--meta-types', '--meta_types',
         help='Specify the meta data types, separate types with commas, example "string,string,long". Available types are [string, double, long, date, boolean]',
         action='store', default=None, required=False)
-    parser.add_argument('--time_format',
+    parser.add_argument('--time-format', '--time_format',
         help='Specify the format of the date/time.',
         action='store', default='%Y:%m:%d %H:%M:%S.%f', required=False)
     parser.add_argument('--header',
@@ -234,7 +234,7 @@ def add_process_csv_basic_arguments(parser):
         action='store_true', default=False, required=False)
 
 def add_process_csv_advanced_arguments(parser):
-    parser.add_argument('--keep_original',
+    parser.add_argument('--keep-original', '--keep_original',
         help='Do not overwrite original images, instead save the processed images in a new directory by adding suffix "_processed" to the import_path.',
         action='store_true', default=False, required=False)
 
@@ -275,7 +275,7 @@ def process_csv(import_path,
         sys.exit(1)
 
     if gps_week_column != None and convert_gps_time == False:
-        print("Error, in order to parse timestamp provided as a combination of GPS week and GPS seconds, you must specify timestamp column and flag --convert_gps_time, exiting...")
+        print("Error, in order to parse timestamp provided as a combination of GPS week and GPS seconds, you must specify timestamp column and flag --convert-gps-time, exiting...")
         sys.exit(1)
 
     if (convert_gps_time != False or convert_utc_time != False) and timestamp_column == None:

--- a/mapillary_tools/process_csv.py
+++ b/mapillary_tools/process_csv.py
@@ -183,6 +183,60 @@ def read_csv(csv_path, delimiter=",", header=False):
         csv_data = zip(*csvreader)
     return csv_data
 
+def add_process_csv_basic_arguments(parser):
+    parser.add_argument('--csv_path',
+        help='Provide the path to the csv file.',
+        action='store', required=True)
+    parser.add_argument('--delimiter',
+        help='Delimiter between the columns.',
+        action='store', default=',', required=False)
+    parser.add_argument('--convert_gps_time',
+        help='Convert gps time in ticks to standard time.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--convert_utc_time',
+        help='Convert utc epoch time in seconds or milliseconds.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--filename_column',
+        help='Specify the column number of image filename, counting from 1 on.',
+        action='store', type=int, required=False)
+    parser.add_argument('--timestamp_column',
+        help='Specify the column number of image timestamp, counting from 1 on.',
+        action='store', type=int, required=False)
+    parser.add_argument('--latitude_column',
+        help='Specify the column number of image latitude, counting from 1 on.',
+        action='store', type=int, required=False)
+    parser.add_argument('--longitude_column',
+        help='Specify the column number of image longitude, counting from 1 on.',
+        action='store', type=int, required=False)
+    parser.add_argument('--heading_column',
+        help='Specify the column number of image heading, counting from 1 on.',
+        action='store', type=int, required=False)
+    parser.add_argument('--altitude_column',
+        help='Specify the column number of image altitude, counting from 1 on.',
+        action='store', type=int, required=False)
+    parser.add_argument('--gps_week_column',
+        help='Specify the column number of image timestamps gps week, counting from 1 on. Used only with --convert_gps_time.',
+        action='store', type=int, required=False)
+    parser.add_argument('--meta_columns',
+        help='Specify the column numbers containing meta data, separate numbers with commas, example "7,9,10".',
+        action='store', default=None, required=False)
+    parser.add_argument('--meta_names',
+        help='Specify the meta data names, separate names with commas, example "meta_data_1,meta_data2,meta_data3".',
+        action='store', default=None, required=False)
+    parser.add_argument('--meta_types',
+        help='Specify the meta data types, separate types with commas, example "string,string,long". Available types are [string, double, long, date, boolean]',
+        action='store', default=None, required=False)
+    parser.add_argument('--time_format',
+        help='Specify the format of the date/time.',
+        action='store', default='%Y:%m:%d %H:%M:%S.%f', required=False)
+    parser.add_argument('--header',
+        help='The csv file includes a header.',
+        action='store_true', default=False, required=False)
+
+def add_process_csv_advanced_arguments(parser):
+    parser.add_argument('--keep_original',
+        help='Do not overwrite original images, instead save the processed images in a new directory by adding suffix "_processed" to the import_path.',
+        action='store_true', default=False, required=False)
 
 def process_csv(import_path,
                 csv_path,

--- a/mapillary_tools/process_geotag_properties.py
+++ b/mapillary_tools/process_geotag_properties.py
@@ -4,6 +4,30 @@ import sys
 from .error import print_error
 
 
+def add_geotag_arguments(parser):
+    parser.add_argument('--geotag_source',
+        help='Provide the source of date/time and gps information needed for geotagging.',
+        action='store', default='exif', required=False,
+        choices=['exif', 'gpx', 'gopro_videos', 'nmea', 'blackvue_videos'])
+    parser.add_argument('--geotag_source_path',
+        help='Provide the path to the file source of date/time and gps information needed for geotagging.',
+        action='store', default=None, required=False)
+    parser.add_argument('--local_time',
+        help='Assume image timestamps are in your local time.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--sub_second_interval',
+        help='Sub second time between shots. Used to set image times with sub-second precision.',
+        type=float, default=0.0, required=False)
+    parser.add_argument('--offset_time',
+        help='Time offset between the camera and the gps device, in seconds.',
+        type=float, default=0.0, required=False)
+    parser.add_argument('--offset_angle',
+        help='Offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing).',
+        type=float, default=0.0, required=False)
+    parser.add_argument('--use_gps_start_time',
+        help='Use GPS trace starting time in case of derivating timestamp from filename.',
+        action='store_true', default=False, required=False)
+
 def process_geotag_properties(import_path,
                               geotag_source="exif",
                               geotag_source_path=None,

--- a/mapillary_tools/process_geotag_properties.py
+++ b/mapillary_tools/process_geotag_properties.py
@@ -5,29 +5,29 @@ from .error import print_error
 
 
 def add_offset_angle_argument(parser):
-    parser.add_argument('--offset_angle',
+    parser.add_argument('--offset-angle', '--offset_angle',
         help='Offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing).',
         type=float, default=0.0, required=False)
 
 def add_geotag_arguments(parser):
-    parser.add_argument('--geotag_source',
+    parser.add_argument('--geotag-source', '--geotag_source',
         help='Provide the source of date/time and gps information needed for geotagging.',
         action='store', default='exif', required=False,
         choices=['exif', 'gpx', 'gopro_videos', 'nmea', 'blackvue_videos'])
-    parser.add_argument('--geotag_source_path',
+    parser.add_argument('--geotag-source-path', '--geotag_source_path',
         help='Provide the path to the file source of date/time and gps information needed for geotagging.',
         action='store', default=None, required=False)
-    parser.add_argument('--local_time',
+    parser.add_argument('--local-time', '--local_time',
         help='Assume image timestamps are in your local time.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--sub_second_interval',
+    parser.add_argument('--sub-second-interval', '--sub_second_interval',
         help='Sub second time between shots. Used to set image times with sub-second precision.',
         type=float, default=0.0, required=False)
-    parser.add_argument('--offset_time',
+    parser.add_argument('--offset-time', '--offset_time',
         help='Time offset between the camera and the gps device, in seconds.',
         type=float, default=0.0, required=False)
     add_offset_angle_argument(parser)
-    parser.add_argument('--use_gps_start_time',
+    parser.add_argument('--use-gps-start-time', '--use_gps_start_time',
         help='Use GPS trace starting time in case of derivating timestamp from filename.',
         action='store_true', default=False, required=False)
 

--- a/mapillary_tools/process_geotag_properties.py
+++ b/mapillary_tools/process_geotag_properties.py
@@ -4,6 +4,11 @@ import sys
 from .error import print_error
 
 
+def add_offset_angle_argument(parser):
+    parser.add_argument('--offset_angle',
+        help='Offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing).',
+        type=float, default=0.0, required=False)
+
 def add_geotag_arguments(parser):
     parser.add_argument('--geotag_source',
         help='Provide the source of date/time and gps information needed for geotagging.',
@@ -21,9 +26,7 @@ def add_geotag_arguments(parser):
     parser.add_argument('--offset_time',
         help='Time offset between the camera and the gps device, in seconds.',
         type=float, default=0.0, required=False)
-    parser.add_argument('--offset_angle',
-        help='Offset camera angle (90 for right facing, 180 for rear facing, -90 for left facing).',
-        type=float, default=0.0, required=False)
+    add_offset_angle_argument(parser)
     parser.add_argument('--use_gps_start_time',
         help='Use GPS trace starting time in case of derivating timestamp from filename.',
         action='store_true', default=False, required=False)

--- a/mapillary_tools/process_import_meta_properties.py
+++ b/mapillary_tools/process_import_meta_properties.py
@@ -7,6 +7,43 @@ from exif_read import ExifRead
 from tqdm import tqdm
 from .error import print_error
 
+def add_import_meta_arguments(parser):
+    parser.add_argument('--device_make',
+        help='Specify device manufacturer. Note this input has precedence over the input read from the import source file.',
+        default=None, required=False)
+    parser.add_argument('--device_model',
+        help='Specify device model. Note this input has precedence over the input read from the import source file.',
+        default=None, required=False)
+    parser.add_argument('--add_file_name',
+        help='Add original file name to EXIF. Note this input has precedence over the input read from the import source file.',
+        action='store_true', required=False)
+    parser.add_argument('--exclude_import_path',
+        help='If local file name is to be added exclude import_path from the name.',
+        action='store_true', required=False)
+    parser.add_argument('--exclude_path',
+        help='If local file name is to be added, specify the path to be excluded.',
+        default=None, required=False)
+    parser.add_argument('--add_import_date',
+        help='Add import date.',
+        action='store_true', required=False)
+    parser.add_argument('--windows_path',
+        help='If local file name is to be added with --add_file_name, added it as a windows path.',
+        action='store_true', required=False)
+    parser.add_argument('--orientation',
+        help='Specify the image orientation in degrees. Note this might result in image rotation. Note this input has precedence over the input read from the import source file.',
+        type=int, default=None, required=False,
+        choices=[0, 90, 180, 270])
+    parser.add_argument('--GPS_accuracy',
+        help='GPS accuracy in meters. Note this input has precedence over the input read from the import source file.',
+        default=None, required=False)
+    parser.add_argument('--camera_uuid',
+        help='Custom string used to differentiate different captures taken with the same camera make and model.',
+        default=None, required=False)
+    parser.add_argument('--custom_meta_data',
+        help='Add custom meta data to all images. Required format of input is a string, consisting of the meta data name, type and value, separated by a comma for each entry, where entries are separated by semicolon. Supported types are long, double, string, boolean, date. Example for two meta data entries "random_name1,double,12.34;random_name2,long,1234".',
+        default=None, required=False)
+
+
 META_DATA_TYPES = {"strings": str,
                    "doubles": float,
                    "longs": long,

--- a/mapillary_tools/process_import_meta_properties.py
+++ b/mapillary_tools/process_import_meta_properties.py
@@ -8,38 +8,38 @@ from tqdm import tqdm
 from .error import print_error
 
 def add_import_meta_arguments(parser):
-    parser.add_argument('--device_make',
+    parser.add_argument('--device-make', '--device_make',
         help='Specify device manufacturer. Note this input has precedence over the input read from the import source file.',
         default=None, required=False)
-    parser.add_argument('--device_model',
+    parser.add_argument('--device-model', '--device_model',
         help='Specify device model. Note this input has precedence over the input read from the import source file.',
         default=None, required=False)
-    parser.add_argument('--add_file_name',
+    parser.add_argument('--add-file-name', '--add_file_name',
         help='Add original file name to EXIF. Note this input has precedence over the input read from the import source file.',
         action='store_true', required=False)
-    parser.add_argument('--exclude_import_path',
+    parser.add_argument('--exclude-import-path', '--exclude_import_path',
         help='If local file name is to be added exclude import_path from the name.',
         action='store_true', required=False)
-    parser.add_argument('--exclude_path',
+    parser.add_argument('--exclude-path', '--exclude_path',
         help='If local file name is to be added, specify the path to be excluded.',
         default=None, required=False)
-    parser.add_argument('--add_import_date',
+    parser.add_argument('--add-import-date', '--add_import_date',
         help='Add import date.',
         action='store_true', required=False)
-    parser.add_argument('--windows_path',
-        help='If local file name is to be added with --add_file_name, added it as a windows path.',
+    parser.add_argument('--windows-path', '--windows_path',
+        help='If local file name is to be added with --add-file-name, added it as a windows path.',
         action='store_true', required=False)
     parser.add_argument('--orientation',
         help='Specify the image orientation in degrees. Note this might result in image rotation. Note this input has precedence over the input read from the import source file.',
         type=int, default=None, required=False,
         choices=[0, 90, 180, 270])
-    parser.add_argument('--GPS_accuracy',
+    parser.add_argument('--GPS-accuracy', '--GPS_accuracy',
         help='GPS accuracy in meters. Note this input has precedence over the input read from the import source file.',
         default=None, required=False)
-    parser.add_argument('--camera_uuid',
+    parser.add_argument('--camera-uuid', '--camera_uuid',
         help='Custom string used to differentiate different captures taken with the same camera make and model.',
         default=None, required=False)
-    parser.add_argument('--custom_meta_data',
+    parser.add_argument('--custom-meta-data', '--custom_meta_data',
         help='Add custom meta data to all images. Required format of input is a string, consisting of the meta data name, type and value, separated by a comma for each entry, where entries are separated by semicolon. Supported types are long, double, string, boolean, date. Example for two meta data entries "random_name1,double,12.34;random_name2,long,1234".',
         default=None, required=False)
 

--- a/mapillary_tools/process_sequence_properties.py
+++ b/mapillary_tools/process_sequence_properties.py
@@ -14,25 +14,25 @@ MAX_SEQUENCE_LENGTH = 500
 MAX_CAPTURE_SPEED = 45  # in m/s
 
 def add_sequence_arguments(parser):
-    parser.add_argument('--cutoff_distance',
+    parser.add_argument('--cutoff-distance', '--cutoff_distance',
         help='Maximum gps distance in meters within a sequence.',
         type=float, default=600.0, required=False)
-    parser.add_argument('--cutoff_time',
+    parser.add_argument('--cutoff-time', '--cutoff_time',
         help='Maximum time interval in seconds within a sequence.',
         type=float, default=60.0, required=False)
-    parser.add_argument('--interpolate_directions',
+    parser.add_argument('--interpolate-directions', '--interpolate_directions',
         help='Perform interpolation of directions.',
         action='store_true', required=False)
-    parser.add_argument('--keep_duplicates',
+    parser.add_argument('--keep-duplicates', '--keep_duplicates',
         help='Keep duplicates, that is do not flag duplicates for upload exclusion, but keep them to be uploaded.',
         action='store_true', default=False, required=False)
-    parser.add_argument('--duplicate_distance',
+    parser.add_argument('--duplicate-distance', '--duplicate_distance',
         help='Maximum distance for two images to be considered duplicates in meters.',
         type=float, default=0.1, required=False)
-    parser.add_argument('--duplicate_angle',
+    parser.add_argument('--duplicate-angle', '--duplicate_angle',
         help='Maximum angle for two images to be considered duplicates in degrees.',
         type=float, default=5.0, required=False)
-    # --offset_angle is already declared by add_geotag_arguments()
+    # --offset-angle is already declared by add_geotag_arguments()
 
 def finalize_sequence_processing(sequence,
                                  final_file_list,

--- a/mapillary_tools/process_sequence_properties.py
+++ b/mapillary_tools/process_sequence_properties.py
@@ -13,6 +13,26 @@ from .error import print_error
 MAX_SEQUENCE_LENGTH = 500
 MAX_CAPTURE_SPEED = 45  # in m/s
 
+def add_sequence_arguments(parser):
+    parser.add_argument('--cutoff_distance',
+        help='Maximum gps distance in meters within a sequence.',
+        type=float, default=600.0, required=False)
+    parser.add_argument('--cutoff_time',
+        help='Maximum time interval in seconds within a sequence.',
+        type=float, default=60.0, required=False)
+    parser.add_argument('--interpolate_directions',
+        help='Perform interpolation of directions.',
+        action='store_true', required=False)
+    parser.add_argument('--keep_duplicates',
+        help='Keep duplicates, that is do not flag duplicates for upload exclusion, but keep them to be uploaded.',
+        action='store_true', default=False, required=False)
+    parser.add_argument('--duplicate_distance',
+        help='Maximum distance for two images to be considered duplicates in meters.',
+        type=float, default=0.1, required=False)
+    parser.add_argument('--duplicate_angle',
+        help='Maximum angle for two images to be considered duplicates in degrees.',
+        type=float, default=5.0, required=False)
+    # --offset_angle is already declared by add_geotag_arguments()
 
 def finalize_sequence_processing(sequence,
                                  final_file_list,

--- a/mapillary_tools/process_user_properties.py
+++ b/mapillary_tools/process_user_properties.py
@@ -4,6 +4,28 @@ import sys
 from .error import print_error
 
 
+def add_user_arguments(parser):
+    parser.add_argument('--user_name',
+        help='Mapillary user name for the upload.',
+        required=True)
+
+def add_organization_arguments(parser):
+    parser.add_argument('--organization_username',
+        help='Specify organization user name.',
+        default=None, required=False)
+    parser.add_argument('--organization_key',
+        help='Specify organization key.',
+        default=None, required=False)
+    parser.add_argument('--private',
+        help='Specify whether the import is private.',
+        action='store_true', default=False, required=False)
+
+def add_mapillary_arguments(parser):
+    parser.add_argument('--master_upload',
+        help='Process / upload performed on behalf of the specified user account. Note: only for Mapillary employee use.',
+        action='store_true', default=False, required=False)
+
+
 def process_user_properties(import_path,
                             user_name,
                             organization_username=None,

--- a/mapillary_tools/process_user_properties.py
+++ b/mapillary_tools/process_user_properties.py
@@ -5,15 +5,15 @@ from .error import print_error
 
 
 def add_user_arguments(parser):
-    parser.add_argument('--user_name',
+    parser.add_argument('--user-name', '--user_name',
         help='Mapillary user name for the upload.',
         required=True)
 
 def add_organization_arguments(parser):
-    parser.add_argument('--organization_username',
+    parser.add_argument('--organization-username', '--organization_username',
         help='Specify organization user name.',
         default=None, required=False)
-    parser.add_argument('--organization_key',
+    parser.add_argument('--organization-key', '--organization_key',
         help='Specify organization key.',
         default=None, required=False)
     parser.add_argument('--private',
@@ -21,7 +21,7 @@ def add_organization_arguments(parser):
         action='store_true', default=False, required=False)
 
 def add_mapillary_arguments(parser):
-    parser.add_argument('--master_upload',
+    parser.add_argument('--master-upload', '--master_upload',
         help='Process / upload performed on behalf of the specified user account. Note: only for Mapillary employee use.',
         action='store_true', default=False, required=False)
 

--- a/mapillary_tools/process_video.py
+++ b/mapillary_tools/process_video.py
@@ -45,16 +45,16 @@ def timestamps_from_filename(video_filename,
     return capture_times
 
 def add_video_arguments(parser):
-    parser.add_argument('--video_import_path',
+    parser.add_argument('--video-import-path', '--video_import_path',
         help='Path to a video or a directory with one or more video files.',
         action='store', default=None, required=False)
-    parser.add_argument('--video_sample_interval',
+    parser.add_argument('--video-sample-interval', '--video_sample_interval',
         help='Time interval for sampled video frames in seconds.',
         type=float, default=2.0, required=False)
-    parser.add_argument('--video_duration_ratio',
+    parser.add_argument('--video-duration-ratio', '--video_duration_ratio',
         help='Real time video duration ratio of the under or oversampled video duration.',
         type=float, default=1.0, required=False)
-    parser.add_argument('--video_start_time',
+    parser.add_argument('--video-start-time', '--video_start_time',
         help='Video start time in epochs (milliseconds).',
         type=int, default=None, required=False)
 

--- a/mapillary_tools/process_video.py
+++ b/mapillary_tools/process_video.py
@@ -44,6 +44,19 @@ def timestamps_from_filename(video_filename,
                                                      adjustment))
     return capture_times
 
+def add_video_arguments(parser):
+    parser.add_argument('--video_import_path',
+        help='Path to a video or a directory with one or more video files.',
+        action='store', default=None, required=False)
+    parser.add_argument('--video_sample_interval',
+        help='Time interval for sampled video frames in seconds.',
+        type=float, default=2.0, required=False)
+    parser.add_argument('--video_duration_ratio',
+        help='Real time video duration ratio of the under or oversampled video duration.',
+        type=float, default=1.0, required=False)
+    parser.add_argument('--video_start_time',
+        help='Video start time in epochs (milliseconds).',
+        type=int, default=None, required=False)
 
 def sample_video(video_import_path,
                  import_path,

--- a/mapillary_tools/processing.py
+++ b/mapillary_tools/processing.py
@@ -906,7 +906,7 @@ def user_properties_master(user_name,
         master_key = uploader.get_master_key()
     except:
         print_error("Error, no master key found.")
-        print("If you are a user, run the process script without the --master_upload, if you are a Mapillary employee, make sure you have the master key in your config file.")
+        print("If you are a user, run the process script without the --master-upload, if you are a Mapillary employee, make sure you have the master key in your config file.")
         return None
 
     user_properties = {"MAPVideoSecure": master_key}

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -8,15 +8,15 @@ from exif_aux import verify_mapillary_tag
 from . import ipc
 
 def add_upload_arguments(parser):
-    parser.add_argument('--number_threads',
+    parser.add_argument('--number-threads', '--number_threads',
         help='Specify the number of upload threads.',
         type=int, default=None, required=False)
-    parser.add_argument('--max_attempts',
+    parser.add_argument('--max-attempts', '--max_attempts',
         help='Specify the maximum number of attempts to upload.',
         type=int, default=None, required=False)
 
 def add_dry_run_arguments(parser):
-    parser.add_argument('--dry_run',
+    parser.add_argument('--dry-run', '--dry_run',
         help='Disable actual upload. Used for debugging only',
         type=bool, default=False, required=False)
 

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -7,6 +7,19 @@ import json
 from exif_aux import verify_mapillary_tag
 from . import ipc
 
+def add_upload_arguments(parser):
+    parser.add_argument('--number_threads',
+        help='Specify the number of upload threads.',
+        type=int, default=None, required=False)
+    parser.add_argument('--max_attempts',
+        help='Specify the maximum number of attempts to upload.',
+        type=int, default=None, required=False)
+
+def add_dry_run_arguments(parser):
+    parser.add_argument('--dry_run',
+        help='Disable actual upload. Used for debugging only',
+        type=bool, default=False, required=False)
+
 def upload(import_path, verbose=False, skip_subfolders=False, number_threads=None, max_attempts=None, video_import_path=None, dry_run=False,api_version=1.0):
     '''
     Upload local images to Mapillary


### PR DESCRIPTION
The first patch fixes post_process to use the --video_import_path instead of --video_file which has been removed months ago.
The deduplicate the declaration of the command line options (going from 335 add_argument() calls down to 104).
And the final patch adds support for all-dash command line option names (e.g. --skip-subfolders) as is the norm everywhere. Of course it preserves support for the underscore names for backward compatibility.
