### PR TITLE
feat: allow scoped organization downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ mapillary_tools download --import_path "path/to/images" --output_folder "path/to
 ```
 
 ##### Downloading by image key
-Downloading blurred originals by image key works **only** for private imagery which belongs to an organization.
+You can download any images which belong to an organization (whether private or public) by using this command. This command download **private images by default**, to download publicly uploaded images from the given organization you need to pass `--private=false` flag. There are some access restrictions when it comes to downloading the data: you have to be authenticated as an organization admin/member to download the imagery. Contributors don't have access to these command. Attempting to download an organization image (whether public/private) as a contributor will yield an `You don't have sufficient organization access to download this image` error.
 
 ```bash
 mapillary_tools download --by_property key \
@@ -433,6 +433,7 @@ mapillary_tools download --by_property key \
 
 The command above specifies will attempt to download all privately blurred images for the organization `org_key`. These are all flags the command supports:
 - `organization_keys` - what are the keys of organizations which own the images
+- `private` - download private/non-private images (default is `--private=true`)
 - `user_name` - the username of the authenticate user (see `authenticate` section)
 - `import_path` - it's ignored in this script
 - `output_folder` - where to download the images to

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ mapillary_tools download --import_path "path/to/images" --output_folder "path/to
 ```
 
 ##### Downloading by image key
-You can download any images which belong to an organization (whether private or public) by using this command. This command download **private images by default**, to download publicly uploaded images from the given organization you need to pass `--private=false` flag. There are some access restrictions when it comes to downloading the data: you have to be authenticated as an organization admin/member to download the imagery. Contributors don't have access to these command. Attempting to download an organization image (whether public/private) as a contributor will yield an `You don't have sufficient organization access to download this image` error.
+You can download any images which belong to an organization (whether private or public) by using this command. This command downloads **private images by default**, to download publicly uploaded images from the given organization you need to pass `--private=false` flag. There are some access restrictions when it comes to downloading the data: you have to be authenticated as an organization admin/member to download the imagery. Contributors don't have access to this command. Attempting to download an organization image (whether public/private) as a contributor will yield an `You don't have sufficient organization access to download this image` error.
 
 ```bash
 mapillary_tools download --by_property key \

--- a/mapillary_tools/commands/download.py
+++ b/mapillary_tools/commands/download.py
@@ -28,6 +28,11 @@ either for a specified import path or by image keys.
                             help="Since when to pull the images (YYYY-MM-DD)")
         parser.add_argument('--end_time',
                             help="Until when to pull the images (YYYY-MM-DD)")
+        parser.add_argument('--private',
+                            help="Download private/public organization images",
+                            type=str,
+                            choices=['true', 'false'],
+                            default='true')
 
     def add_advanced_arguments(self, parser):
         parser.add_argument(

--- a/mapillary_tools/download_blurred.py
+++ b/mapillary_tools/download_blurred.py
@@ -104,9 +104,11 @@ def query_search_api(headers, **kwargs):
     per_page = int(kwargs['per_page'])
     for k, v in kwargs.iteritems():
         if v is not None:
-            set_params.append((k, str(v)))
+            if k == 'private' and v == 'false':
+                pass
+            else:
+                set_params.append((k, str(v)))
 
-    set_params.append(('private', 'true'))
     set_params.append(('client_id', uploader.CLIENT_ID))
     params = urllib.urlencode(set_params)
 


### PR DESCRIPTION
## Overview
This PR updates how the download blurred originals command works, it relies on the APIs I built recently. These are the changes:

- An admin **can download any image**, whether private/public which belongs to an organization
- A member **can download any image**, whether private/public which belongs to an organization
- A contributor **cannot** download any images whether private/public which belongs to an organization

These changes are mostly cosmetic and don't effectively change the previous behavior, besides extending it by `--private` flag which now accepts `false` so the organization user has a chance to download publicly uploaded organization imagery.

### Notes
I've updated the README, please let know if this makes sense @katrinhumal.