### PR TITLE
Feat dynamic aws key

### DIFF
--- a/mapillary_structure.json
+++ b/mapillary_structure.json
@@ -57,7 +57,7 @@
       "dockerparameters": {
          "command": "script/run process",
          "volumes": ["./tests:/mapillary_source/tests"],
-         "environment": ["GLOBAL_CONFIG_FILEPATH=/mapillary_source/tests/.config/mapillary/configs/MkJKbDA0bnZuZlcxeTJHTmFqN3g1dzo1YTM0NjRkM2EyZGU5MzBh"]
+         "environment": ["GLOBAL_CONFIG_FILEPATH=/mapillary_source/tests/.config/mapillary/configs/YWFhYWFhYWFhYWFhYWFhYWFhYWFhYTphcHBfYQ=="]
       },
       "config_vars": [],
       "marathon_name": "",

--- a/mapillary_structure.json
+++ b/mapillary_structure.json
@@ -26,7 +26,8 @@
       "extDependencies": [],
       "dockerparameters": {
          "command": "script/run upload",
-         "volumes": ["./tests:/mapillary_source/tests"]
+         "volumes": ["./tests:/mapillary_source/tests"],
+         "environment": ["GLOBAL_CONFIG_FILEPATH=/mapillary_source/tests/.config/mapillary/configs/YWFhYWFhYWFhYWFhYWFhYWFhYWFhYTphcHBfYQ=="]
       },
       "config_vars": [],
       "marathon_name": "",

--- a/mapillary_tools/edit_config.py
+++ b/mapillary_tools/edit_config.py
@@ -34,6 +34,7 @@ def edit_config(config_file=None, user_name=None, user_email=None, user_password
         user_items["user_upload_token"] = "Dummy_upload_token"
         user_items["user_permission_hash"] = "Dummy_user_permission_hash"
         user_items["user_signature_hash"] = "Dummy_user_signature_hash"
+        user_items["aws_access_key_id"] = "Dummy_aws_access_key_id"
 
         section = user_name
         config.update_config(config_file_path, section, user_items)
@@ -98,7 +99,7 @@ def edit_config(config_file=None, user_name=None, user_email=None, user_password
 def edit_config_with_jwt(jwt, config_file_path):
     user = uploader.get_user(jwt)
 
-    user_permission_hash, user_signature_hash = uploader.get_user_hashes(
+    user_permission_hash, user_signature_hash, aws_access_key_id = uploader.get_user_hashes(
         user['key'], jwt)
 
     user_items = {}
@@ -107,5 +108,6 @@ def edit_config_with_jwt(jwt, config_file_path):
     user_items["user_upload_token"] = jwt
     user_items["user_permission_hash"] = user_permission_hash
     user_items["user_signature_hash"] = user_signature_hash
+    user_items["aws_access_key_id"] = aws_access_key_id
 
     config.update_config(config_file_path, user['username'], user_items)

--- a/mapillary_tools/edit_config.py
+++ b/mapillary_tools/edit_config.py
@@ -7,8 +7,10 @@ import uploader
 '''
 CLIENT_ID = os.getenv("MAPILLARY_WEB_CLIENT_ID",
                       "MkJKbDA0bnZuZlcxeTJHTmFqN3g1dzo1YTM0NjRkM2EyZGU5MzBh")
-GLOBAL_CONFIG_FILEPATH = os.path.join(
-    os.path.expanduser('~'), ".config", "mapillary", 'configs',CLIENT_ID)
+
+GLOBAL_CONFIG_FILEPATH = os.getenv(
+    "GLOBAL_CONFIG_FILEPATH",
+    os.path.join(os.path.expanduser('~'), ".config", "mapillary", 'configs', CLIENT_ID))
 
 
 def edit_config(config_file=None, user_name=None, user_email=None, user_password=None, jwt=None, force_overwrite=False, user_key=None,api_version=1.0, upload_type='Video'):

--- a/mapillary_tools/process_upload_params.py
+++ b/mapillary_tools/process_upload_params.py
@@ -65,7 +65,7 @@ def process_upload_params(import_path,
                                                       "failed",
                                                       verbose)
             sys.exit(1)
-        if credentials == None or "user_upload_token" not in credentials or "user_permission_hash" not in credentials or "user_signature_hash" not in credentials:
+        if credentials == None or "user_upload_token" not in credentials or "user_permission_hash" not in credentials or "user_signature_hash" not in credentials or "aws_access_key_id" not in credentials:
             print_error(
                 "Error, user authentication failed for user " + user_name)
             processing.create_and_log_process_in_list(process_file_list,
@@ -77,6 +77,7 @@ def process_upload_params(import_path,
         user_upload_token = credentials["user_upload_token"]
         user_permission_hash = credentials["user_permission_hash"]
         user_signature_hash = credentials["user_signature_hash"]
+        aws_access_key_id = credentials["aws_access_key_id"]
         user_key = credentials["MAPSettingsUserKey"]
 
     for image in tqdm(process_file_list, desc="Processing image upload parameters"):
@@ -101,6 +102,7 @@ def process_upload_params(import_path,
                                                                           user_permission_hash,
                                                                           user_signature_hash,
                                                                           user_key,
+                                                                          aws_access_key_id,
                                                                           verbose)
         processing.create_and_log_process(image,
                                           "upload_params_process",

--- a/mapillary_tools/processing.py
+++ b/mapillary_tools/processing.py
@@ -368,7 +368,7 @@ def get_geotag_properties_from_gps_trace(image, capture_time, gps_trace, offset_
     return geotag_properties
 
 
-def get_upload_param_properties(log_root, image, user_name, user_upload_token, user_permission_hash, user_signature_hash, user_key, verbose=False):
+def get_upload_param_properties(log_root, image, user_name, user_upload_token, user_permission_hash, user_signature_hash, user_key, aws_access_key_id, verbose=False):
 
     if not os.path.isdir(log_root):
         print("Warning, sequence process has not been done for image " + image +
@@ -416,7 +416,7 @@ def get_upload_param_properties(log_root, image, user_name, user_upload_token, u
         "permission": user_permission_hash,
         "signature": user_signature_hash,
         "key": user_name + "/" + sequence_uuid + "/",
-        "aws_key": os.getenv("AWS_ACCESS_KEY_ID", "AKIAR47SN3BMCP62Z54T")
+        "aws_key": aws_access_key_id
     }
 
     try:
@@ -874,6 +874,8 @@ def user_properties(user_name,
         del user_properties["user_permission_hash"]
     if "user_signature_hash" in user_properties:
         del user_properties["user_signature_hash"]
+    if "aws_access_key_id" in user_properties:
+        del user_properties["aws_access_key_id"]
 
     return user_properties
 

--- a/mapillary_tools/processing.py
+++ b/mapillary_tools/processing.py
@@ -416,7 +416,7 @@ def get_upload_param_properties(log_root, image, user_name, user_upload_token, u
         "permission": user_permission_hash,
         "signature": user_signature_hash,
         "key": user_name + "/" + sequence_uuid + "/",
-        "aws_key": os.getenv("AWS_ACCESS_KEY_ID", "AKIAIJJIMLWVT6GBZQIQ")
+        "aws_key": os.getenv("AWS_ACCESS_KEY_ID", "AKIAR47SN3BMCP62Z54T")
     }
 
     try:

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -39,7 +39,7 @@ BOUNDARY_CHARS = string.digits + string.ascii_letters
 NUMBER_THREADS = int(os.getenv('NUMBER_THREADS', '5'))
 MAX_ATTEMPTS = int(os.getenv('MAX_ATTEMPTS', '50'))
 UPLOAD_PARAMS = {"url": MAPILLARY_UPLOAD_URL, "permission": PERMISSION_HASH,  # TODO: This URL is dynamic in api 2.0
-                 "signature": SIGNATURE_HASH, "aws_key": "AKIAI2X3BJAT2W75HILA"}
+                 "signature": SIGNATURE_HASH, "aws_key": "AKIAR47SN3BMCP62Z54T"}
 CLIENT_ID = os.getenv("MAPILLARY_WEB_CLIENT_ID",
                       "MkJKbDA0bnZuZlcxeTJHTmFqN3g1dzo1YTM0NjRkM2EyZGU5MzBh")
 DRY_RUN = bool(os.getenv('DRY_RUN', False))
@@ -680,6 +680,7 @@ def upload_file(filepath, max_attempts, url, permission, signature, key=None, aw
                 break  # attempts
 
             except urllib2.HTTPError as e:
+                print(e.read())
                 print("HTTP error: {} on {}, will attempt upload again for {} more times".format(
                     e, filename, max_attempts - attempt - 1))
                 displayed_upload_error = True

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -579,7 +579,7 @@ def upload_done_file(url, permission, signature, key=None, aws_key=None):
     else:
         s3_key = key + s3_filename
 
-    parameters = {"key": s3_key, "AWSAccessKeyId": aws_key,
+    parameters = {"key": s3_key, "AWSAccessKeyId": aws_key, "acl": "private",
                   "policy": permission, "signature": signature, "Content-Type": "image/jpeg"}
 
     encoded_string = ''
@@ -654,7 +654,7 @@ def upload_file(filepath, max_attempts, url, permission, signature, key=None, aw
     else:
         s3_key = key + s3_filename
 
-    parameters = {"key": s3_key, "AWSAccessKeyId": aws_key,
+    parameters = {"key": s3_key, "AWSAccessKeyId": aws_key, "acl": "private",
                   "policy": permission, "signature": signature, "Content-Type": "image/jpeg"}
 
     with open(filepath, "rb") as f:

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -432,7 +432,7 @@ def prompt_user_for_user_items(user_name):
         user_email, user_password)
     if not upload_token:
         return None
-    user_permission_hash, user_signature_hash = get_user_hashes(
+    user_permission_hash, user_signature_hash, aws_access_key_id = get_user_hashes(
         user_key, upload_token)
 
     user_items["MAPSettingsUsername"] = user_name
@@ -441,6 +441,7 @@ def prompt_user_for_user_items(user_name):
     user_items["user_upload_token"] = upload_token
     user_items["user_permission_hash"] = user_permission_hash
     user_items["user_signature_hash"] = user_signature_hash
+    user_items["aws_access_key_id"] = aws_access_key_id
 
     return user_items
 
@@ -483,7 +484,7 @@ def authenticate_with_email_and_pwd(user_email, user_password):
         print("User name {} does not exist, please try again or contact Mapillary user support.".format(
             user_name))
         sys.exit(1)
-    user_permission_hash, user_signature_hash = get_user_hashes(
+    user_permission_hash, user_signature_hash, aws_access_key_id = get_user_hashes(
         user_key, upload_token)
 
     user_items["MAPSettingsUsername"] = section
@@ -492,6 +493,8 @@ def authenticate_with_email_and_pwd(user_email, user_password):
     user_items["user_upload_token"] = upload_token
     user_items["user_permission_hash"] = user_permission_hash
     user_items["user_signature_hash"] = user_signature_hash
+    user_items["aws_access_key_id"] = aws_access_key_id
+    
     return user_items
 
 
@@ -555,12 +558,15 @@ def get_user_hashes(user_key, upload_token):
     req = urllib2.Request(USER_UPLOAD_URL.format(user_key, CLIENT_ID))
     req.add_header('Authorization', 'Bearer {}'.format(upload_token))
     resp = json.loads(urllib2.urlopen(req).read())
+
     if 'images_hash' in resp:
         user_signature_hash = resp['images_hash']
     if 'images_policy' in resp:
         user_permission_hash = resp['images_policy']
+    if 'aws_access_key_id' in resp:
+        aws_access_key_id = resp['aws_access_key_id']
 
-    return (user_permission_hash, user_signature_hash)
+    return (user_permission_hash, user_signature_hash, aws_access_key_id)
 
 
 def get_user(jwt):

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -494,7 +494,7 @@ def authenticate_with_email_and_pwd(user_email, user_password):
     user_items["user_permission_hash"] = user_permission_hash
     user_items["user_signature_hash"] = user_signature_hash
     user_items["aws_access_key_id"] = aws_access_key_id
-    
+
     return user_items
 
 

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -579,7 +579,7 @@ def upload_done_file(url, permission, signature, key=None, aws_key=None):
     else:
         s3_key = key + s3_filename
 
-    parameters = {"key": s3_key, "AWSAccessKeyId": aws_key, "acl": "private",
+    parameters = {"key": s3_key, "AWSAccessKeyId": aws_key,
                   "policy": permission, "signature": signature, "Content-Type": "image/jpeg"}
 
     encoded_string = ''
@@ -654,7 +654,7 @@ def upload_file(filepath, max_attempts, url, permission, signature, key=None, aw
     else:
         s3_key = key + s3_filename
 
-    parameters = {"key": s3_key, "AWSAccessKeyId": aws_key, "acl": "private",
+    parameters = {"key": s3_key, "AWSAccessKeyId": aws_key,
                   "policy": permission, "signature": signature, "Content-Type": "image/jpeg"}
 
     with open(filepath, "rb") as f:

--- a/script/run
+++ b/script/run
@@ -6,6 +6,7 @@ if [ "$1" = "upload" ];
 then
     map_cluster_wait_for_it $S3_WAIT
     map_cluster_wait_for_it $API_WAIT
+    map_cluster_wait_for_it $API_PROXY_WAIT
     sleep 30
     while :
     do
@@ -16,6 +17,7 @@ elif [ $1 = "process" ];
 then
     map_cluster_wait_for_it $S3_WAIT
     map_cluster_wait_for_it $API_WAIT
+    map_cluster_wait_for_it $API_PROXY_WAIT
     sleep 30
     while :
     do

--- a/tests/integration/mapillary_tools_process_images_provider/setup
+++ b/tests/integration/mapillary_tools_process_images_provider/setup
@@ -3,5 +3,5 @@ from time import sleep
 
 from mapillary_messi.waiters.base_waiter import BaseWaiter
 
-base_waiter = BaseWaiter([], envs=["KAFKA_MAIN_WAIT", "PSQL_MAIN_V2_WAIT", "API_WAIT"])
+base_waiter = BaseWaiter([], envs=["KAFKA_MAIN_WAIT", "PSQL_MAIN_V2_WAIT", "API_WAIT", "API_PROXY_WAIT"])
 base_waiter.wait()

--- a/tests/integration/mapillary_tools_process_images_provider/test_process_images_provider.py
+++ b/tests/integration/mapillary_tools_process_images_provider/test_process_images_provider.py
@@ -77,7 +77,7 @@ class ProcessImagesProviderTestCase(TestCase):
     def _get_user_items(self, user):
         user_items = {}
         upload_token = self._get_upload_token(user)
-        user_permission_hash, user_signature_hash = self._get_user_hashes(user.key, upload_token)
+        user_permission_hash, user_signature_hash, aws_access_key_id = self._get_user_hashes(user.key, upload_token)
 
         user_items["MAPSettingsUsername"] = user.username
         user_items["MAPSettingsUserKey"] = user.key
@@ -85,6 +85,7 @@ class ProcessImagesProviderTestCase(TestCase):
         user_items["user_upload_token"] = upload_token
         user_items["user_permission_hash"] = user_permission_hash
         user_items["user_signature_hash"] = user_signature_hash
+        user_items["aws_access_key_id"] = aws_access_key_id
 
         return user_items
 
@@ -96,4 +97,4 @@ class ProcessImagesProviderTestCase(TestCase):
     def _get_user_hashes(self, user_key, upload_token):
         resp = requests.get(USER_UPLOAD_URL.format(user_key, CLIENT_ID),
                             headers = {"Authorization":"Bearer " + upload_token}).json()
-        return (resp['images_policy'], resp['images_hash'])
+        return (resp['images_policy'], resp['images_hash'], resp['aws_access_key_id'])

--- a/tests/integration/mapillary_tools_process_images_provider/test_process_images_provider.py
+++ b/tests/integration/mapillary_tools_process_images_provider/test_process_images_provider.py
@@ -49,8 +49,10 @@ class ProcessImagesProviderTestCase(TestCase):
         self.user = User(username="mapillary_user")
         self.useFixture(UserFixture([self.user]))
 
-        config.create_config("/mapillary_source/tests/.config/mapillary/config")
-        config.update_config("/mapillary_source/tests/.config/mapillary/config",
+        config_path = "/mapillary_source/tests/.config/mapillary/configs/{}".format(CLIENT_ID)
+
+        config.create_config(config_path)
+        config.update_config(config_path,
                              self.user.username, self._get_user_items(self.user))
 
         super(ProcessImagesProviderTestCase, self).setUp()


### PR DESCRIPTION
Fixes the hardcoded AWS key by using the AWS key provided by the upload API

@jernejaMislej @ybkuang Could you also review these lines too?
https://github.com/mapillary/mapillary_tools/pull/360/files#diff-d16f9199f43eb8f153ddfc6f204f95afR41-R42
I'm not sure how common is to trigger this flow `uploader.upload_file_list_direct(...)`

Also, the `UPLOAD_PARAMS` has a hardcoded policy that expired in 2020-01-01