### PR TITLE
quick fix: Add aws hash unpack in edit_config.py.

### DIFF
--- a/mapillary_tools/edit_config.py
+++ b/mapillary_tools/edit_config.py
@@ -74,7 +74,7 @@ def edit_config(config_file=None, user_name=None, user_email=None, user_password
             print("Authentication failed for user name " +
                   section + ", please try again.")
             sys.exit(1)
-        user_permission_hash, user_signature_hash = uploader.get_user_hashes(
+        user_permission_hash, user_signature_hash, aws_access_key_id = uploader.get_user_hashes(
             user_key, upload_token)
 
         user_items["MAPSettingsUsername"] = section
@@ -83,6 +83,7 @@ def edit_config(config_file=None, user_name=None, user_email=None, user_password
         user_items["user_upload_token"] = upload_token
         user_items["user_permission_hash"] = user_permission_hash
         user_items["user_signature_hash"] = user_signature_hash
+        user_items["mapillary_access_key_id"] = user_signature_hash
         if api_version == 2.0:
             user_items["upload_url"] = uploader.get_upload_url(
                 user_email, user_password, upload_type)


### PR DESCRIPTION
Currently, when you manually provide `--user_name`, `--user_password`, `--user_email` in `edit_config()` in `edit_config.py`, you get an unpacking error: `ValueError: too many values to unpack`

It turns out that it's missing the `aws_access_key_id` return value from `get_user_key()` (from `uploader.py`) when unpacking.

Both `prompt_user_for_user_items()` and `authenticate_with_email_and_pwd()` from `uploader.py` have this fix.