### PR TITLE
skip blackvue video that has no GPS data found

### DIFF
--- a/mapillary_tools/processing.py
+++ b/mapillary_tools/processing.py
@@ -245,11 +245,15 @@ def geotag_from_blackvue_video(
         )
 
         if not gpx_path or not os.path.isfile(gpx_path):
-            print_error(f"Warning: Skipping blackvue video that has no GPS data found: {blackvue_video}")
+            print_error(
+                f"Warning: Skipping blackvue video that has no GPS data found: {blackvue_video}"
+            )
             continue
 
         if is_stationary_video:
-            print_error(f"Warning: Skipping stationary blackvue video: {blackvue_video}")
+            print_error(
+                f"Warning: Skipping stationary blackvue video: {blackvue_video}"
+            )
             continue
 
         process_file_sublist = [

--- a/mapillary_tools/processing.py
+++ b/mapillary_tools/processing.py
@@ -245,10 +245,11 @@ def geotag_from_blackvue_video(
         )
 
         if not gpx_path or not os.path.isfile(gpx_path):
-            raise RuntimeError(f"Error, GPX path {gpx_path} not found")
+            print_error(f"Warning: Skipping blackvue video that has no GPS data found: {blackvue_video}")
+            continue
 
         if is_stationary_video:
-            print_error("Warning: Skipping stationary video")
+            print_error(f"Warning: Skipping stationary blackvue video: {blackvue_video}")
             continue
 
         process_file_sublist = [


### PR DESCRIPTION
For some reason tools can't extract GPS data from some blackvue videos, we should skip these videos instead of stop the whole process.

Fixes https://github.com/mapillary/mapillary_tools/issues/394