### PR TITLE
Write upload history after finish_upload is done

### DIFF
--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -174,8 +174,8 @@ def _setup_write_upload_history(
     params: T.Dict,
     descs: T.Optional[T.List[types.ImageDescriptionFile]] = None,
 ) -> None:
-    @emitter.on("upload_end")
-    def upload_start(payload: uploader.Progress):
+    @emitter.on("upload_finished")
+    def upload_finished(payload: uploader.Progress):
         sequence_uuid = payload.get("sequence_uuid")
         md5sum = payload["md5sum"]
         if sequence_uuid is None or descs is None:

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -423,4 +423,7 @@ def _upload_fp(
     except requests.HTTPError as ex:
         raise upload_api_v4.wrap_http_exception(ex) from ex
 
+    if emitter:
+        emitter.emit("upload_finished", mutable_payload)
+
     return cluster_id


### PR DESCRIPTION
https://github.com/mapillary/mapillary_tools/issues/450

Before wrote history right after upload is done, now write history after both upload and finish_upload API are done.