### PR TITLE
fix: set timeout for requests

### DIFF
--- a/mapillary_tools/api_v4.py
+++ b/mapillary_tools/api_v4.py
@@ -15,6 +15,7 @@ MAPILLARY_CLIENT_TOKEN = os.getenv(
 MAPILLARY_GRAPH_API_ENDPOINT = os.getenv(
     "MAPILLARY_GRAPH_API_ENDPOINT", "https://graph.mapillary.com"
 )
+REQUESTS_TIMEOUT = 60  # 1 minutes
 
 
 def get_upload_token(email: str, password: str) -> requests.Response:
@@ -22,6 +23,7 @@ def get_upload_token(email: str, password: str) -> requests.Response:
         f"{MAPILLARY_GRAPH_API_ENDPOINT}/login",
         params={"access_token": MAPILLARY_CLIENT_TOKEN},
         json={"email": email, "password": password, "locale": "en_US"},
+        timeout=REQUESTS_TIMEOUT,
     )
     resp.raise_for_status()
     return resp
@@ -38,6 +40,7 @@ def fetch_organization(
         headers={
             "Authorization": f"OAuth {user_access_token}",
         },
+        timeout=REQUESTS_TIMEOUT,
     )
     resp.raise_for_status()
     return resp
@@ -60,6 +63,7 @@ def logging(
         headers={
             "Authorization": f"OAuth {access_token}",
         },
+        timeout=REQUESTS_TIMEOUT,
     )
     resp.raise_for_status()
     return resp

--- a/mapillary_tools/upload_api_v4.py
+++ b/mapillary_tools/upload_api_v4.py
@@ -16,7 +16,13 @@ MAPILLARY_UPLOAD_ENDPOINT = os.getenv(
 )
 DEFAULT_CHUNK_SIZE = 1024 * 1024 * 16
 REQUESTS_TIMEOUT = 60  # 1 minutes
-# Make sure the largest possible chunks can be uploaded before this timeout
+# According to the docs, UPLOAD_REQUESTS_TIMEOUT sets both the "connection timeout"
+# and "read timeout": https://docs.python-requests.org/en/latest/user/advanced/#timeouts
+# In my test, however, the connection timeout does not only include the time for connection,
+# but also the time for uploading the actual data.
+# i.e. if your data uploading can't finish in this timeout, it will throw:
+# ConnectionError: ('Connection aborted.', timeout('The write operation timed out'))
+# so make sure the largest possible chunks can be uploaded before this timeout
 UPLOAD_REQUESTS_TIMEOUT = 10 * 60  # 10 minutes
 
 

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -380,6 +380,8 @@ def _upload_fp(
     if emitter:
         emitter.emit("upload_start", mutable_payload)
 
+    MAX_RETRIES = 200
+
     while True:
         fp.seek(0, io.SEEK_SET)
         try:
@@ -396,14 +398,20 @@ def _upload_fp(
                 fp, chunk_size=chunk_size, offset=offset
             )
         except Exception as ex:
-            if retries < 200 and is_retriable_exception(ex):
+            if retries < MAX_RETRIES and is_retriable_exception(ex):
                 if emitter:
                     emitter.emit("upload_interrupted", mutable_payload)
                 retries += 1
                 sleep_for = min(2 ** retries, 16)
                 LOG.warning(
-                    f"Error uploading, resuming in {sleep_for} seconds",
-                    exc_info=True,
+                    f"Error uploading offset %s chunk_size %d: %s: %s",
+                    mutable_payload.get("offset"),
+                    chunk_size,
+                    ex.__class__.__name__,
+                    str(ex),
+                )
+                LOG.info(
+                    "Retrying in %d seconds (%d/%d)", sleep_for, retries, MAX_RETRIES
                 )
                 time.sleep(sleep_for)
             else:

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -382,6 +382,8 @@ def _upload_fp(
 
     MAX_RETRIES = 200
 
+    offset = None
+
     while True:
         fp.seek(0, io.SEEK_SET)
         try:
@@ -404,9 +406,10 @@ def _upload_fp(
                 retries += 1
                 sleep_for = min(2 ** retries, 16)
                 LOG.warning(
-                    f"Error uploading offset %s chunk_size %d: %s: %s",
-                    mutable_payload.get("offset"),
+                    # use %s instead of %d because offset could be None
+                    f"Error uploading chunk_size %d at offset %s: %s: %s",
                     chunk_size,
+                    offset,
                     ex.__class__.__name__,
                     str(ex),
                 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ piexif==1.1.3
 gpxpy==1.4.2
 pymp4==1.1.0
 pynmea2==1.12.0
-requests==2.20.0
+requests>=2.20.0,<3.0.0
 tqdm>=4.0,<5.0
 typing_extensions
 jsonschema


### PR DESCRIPTION
The default timeout for requests is None, which will wait forever.
This PR sets the upload timeout to 10 minutes, and the other request timeouts to 1 minute.

- fix: add timeouts for all HTTP requests
- Simplify retryable error messages
