### PR TITLE
fix: the possible KeyError when fetch offset failed

### DIFF
--- a/mapillary_tools/upload_api_v4.py
+++ b/mapillary_tools/upload_api_v4.py
@@ -223,6 +223,10 @@ class FakeUploadService(UploadService):
         return 0
 
     def fetch_offset(self) -> int:
+        if random.random() <= self._error_ratio:
+            raise requests.ConnectionError(
+                f"TEST ONLY: Partially uploaded with error ratio {self._error_ratio}"
+            )
         filename = os.path.join(self._upload_path, self.session_key)
         if not os.path.exists(filename):
             return 0


### PR DESCRIPTION
When fetch_offset failed, it's possible to read an unexisting key from the progress dict. This PR fixes that.
