### PR TITLE
feat: add commands for uploading blackvue/zip directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ mapillary_tools upload_blackvue "video_file_name.mp4" \
 Upload all BlackVue videos (*.mp4) under the folder:
 
 ```shell
-mapillary_tools upload_blackvue "path/to/blackvue_videos"
+mapillary_tools upload_blackvue "path/to/blackvue_videos/"
 ```
 
 ### Video Process

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ mapillary_tools process_and_upload "path/to/images/"
 Upload BlackVue videos:
 
 ```shell
-mapillary_tools upload "path/to/blackvue_videos/*.mp4"
+mapillary_tools upload_blackvue "path/to/blackvue_videos/"
 ```
 
 ## Requirements
@@ -175,9 +175,15 @@ Upload a BlackVue video with file name `video_file_name.mp4` to user `mly_user` 
 . It is optional to specify `--user_name` if you have only one user [authenticated](#authenticate).
 
 ```shell
-mapillary_tools upload "video_file_name.mp4" \
+mapillary_tools upload_blackvue "video_file_name.mp4" \
     --user_name "mly_user" \
     --organization_key "mly_organization_id"
+```
+
+Upload all BlackVue videos (*.mp4) under the folder:
+
+```shell
+mapillary_tools upload_blackvue "path/to/blackvue_videos"
 ```
 
 ### Video Process
@@ -374,17 +380,10 @@ Zip processed images in `path/to/images/` and write zip files in `path/to/zipped
 mapillary_tools zip "path/to/images/" "path/to/zipped_images/"
 ```
 
-Choose the image description file to write when zipping images:
+Upload all the zip files (*.zip) under the folder:
 
 ```shell
-mapillary_tools zip "path/to/images/" "path/to/zipped_images/" \
-    --desc_path "path/to/image_description.json"
-```
-
-Then upload the zip files separately:
-
-```shell
-mapillary_tools upload path/to/zipped_images/*.zip
+mapillary_tools upload_zip "path/to/zipped_images/"
 ```
 
 ### Upload API

--- a/mapillary_tools/commands/__main__.py
+++ b/mapillary_tools/commands/__main__.py
@@ -9,6 +9,8 @@ from . import (
     process_and_upload,
     sample_video,
     upload,
+    upload_blackvue,
+    upload_zip,
     video_process,
     video_process_and_upload,
     zip,
@@ -17,6 +19,8 @@ from . import (
 mapillary_tools_commands = [
     process,
     upload,
+    upload_blackvue,
+    upload_zip,
     sample_video,
     video_process,
     authenticate,
@@ -51,7 +55,7 @@ def add_general_arguments(parser, command):
             default=False,
             required=False,
         )
-    elif command in ["upload"]:
+    elif command in ["upload", "upload_blackvue", "upload_zip"]:
         parser.add_argument(
             "import_path",
             help="Path to your images",

--- a/mapillary_tools/commands/__main__.py
+++ b/mapillary_tools/commands/__main__.py
@@ -34,10 +34,8 @@ mapillary_tools_commands = [
 LOG = logging.getLogger("mapillary_tools")
 
 
+# Handle shared arguments/options here
 def add_general_arguments(parser, command):
-    if command == "authenticate":
-        return
-
     if command in ["sample_video", "video_process", "video_process_and_upload"]:
         parser.add_argument(
             "video_import_path",
@@ -55,22 +53,13 @@ def add_general_arguments(parser, command):
             default=False,
             required=False,
         )
-    elif command in ["upload", "upload_blackvue", "upload_zip"]:
+    elif command in ["upload"]:
         parser.add_argument(
             "import_path",
             help="Path to your images",
             nargs="+",
         )
-    elif command in ["zip"]:
-        parser.add_argument(
-            "import_path",
-            help="Path to your images",
-        )
-        parser.add_argument(
-            "zip_dir",
-            help="Path to store zipped images",
-        )
-    else:
+    elif command in ["process", "process_and_upload"]:
         parser.add_argument(
             "import_path",
             help="Path to your images",

--- a/mapillary_tools/commands/upload_blackvue.py
+++ b/mapillary_tools/commands/upload_blackvue.py
@@ -4,8 +4,8 @@ from ..upload import upload_multiple
 
 
 class Command:
-    name = "upload"
-    help = "upload images to Mapillary"
+    name = "upload_blackvue"
+    help = "upload BlackVue videos to Mapillary"
 
     def add_basic_arguments(self, parser):
         group = parser.add_argument_group("upload options")
@@ -15,12 +15,6 @@ class Command:
         group.add_argument(
             "--organization_key",
             help="Specify organization ID",
-            default=None,
-            required=False,
-        )
-        group.add_argument(
-            "--desc_path",
-            help="Specify the path to read image description. Applicable for uploading image directories only",
             default=None,
             required=False,
         )
@@ -38,5 +32,5 @@ class Command:
             for k, v in vars_args.items()
             if k in inspect.getfullargspec(upload_multiple).args
         }
-        args["file_type"] = "images"
+        args["file_type"] = "blackvue"
         upload_multiple(**args)

--- a/mapillary_tools/commands/upload_blackvue.py
+++ b/mapillary_tools/commands/upload_blackvue.py
@@ -8,6 +8,11 @@ class Command:
     help = "upload BlackVue videos to Mapillary"
 
     def add_basic_arguments(self, parser):
+        parser.add_argument(
+            "import_path",
+            help="Path to your BlackVue videos",
+            nargs="+",
+        )
         group = parser.add_argument_group("upload options")
         group.add_argument(
             "--user_name", help="Upload to which Mapillary user account", required=False

--- a/mapillary_tools/commands/upload_zip.py
+++ b/mapillary_tools/commands/upload_zip.py
@@ -4,8 +4,8 @@ from ..upload import upload_multiple
 
 
 class Command:
-    name = "upload"
-    help = "upload images to Mapillary"
+    name = "upload_zip"
+    help = "upload ZIP files to Mapillary"
 
     def add_basic_arguments(self, parser):
         group = parser.add_argument_group("upload options")
@@ -15,12 +15,6 @@ class Command:
         group.add_argument(
             "--organization_key",
             help="Specify organization ID",
-            default=None,
-            required=False,
-        )
-        group.add_argument(
-            "--desc_path",
-            help="Specify the path to read image description. Applicable for uploading image directories only",
             default=None,
             required=False,
         )
@@ -38,5 +32,5 @@ class Command:
             for k, v in vars_args.items()
             if k in inspect.getfullargspec(upload_multiple).args
         }
-        args["file_type"] = "images"
+        args["file_type"] = "zip"
         upload_multiple(**args)

--- a/mapillary_tools/commands/upload_zip.py
+++ b/mapillary_tools/commands/upload_zip.py
@@ -8,6 +8,11 @@ class Command:
     help = "upload ZIP files to Mapillary"
 
     def add_basic_arguments(self, parser):
+        parser.add_argument(
+            "import_path",
+            help="Path to your ZIP files",
+            nargs="+",
+        )
         group = parser.add_argument_group("upload options")
         group.add_argument(
             "--user_name", help="Upload to which Mapillary user account", required=False

--- a/mapillary_tools/commands/zip.py
+++ b/mapillary_tools/commands/zip.py
@@ -10,6 +10,14 @@ class Command:
 
     def add_basic_arguments(self, parser: argparse.ArgumentParser):
         parser.add_argument(
+            "import_path",
+            help="Path to your images",
+        )
+        parser.add_argument(
+            "zip_dir",
+            help="Path to store zipped images",
+        )
+        parser.add_argument(
             "--desc_path",
             help="Specify the path to read image description",
             default=None,

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -656,8 +656,9 @@ def upload(
             )
 
     else:
-        raise exceptions.MapillaryFileNotFoundError(
-            f"Import file or directory not found: {import_path}"
+        LOG.warning(
+            f"Import file or directory not found: %s",
+            import_path,
         )
 
     upload_summary = _summarize(stats)

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -627,16 +627,26 @@ def upload(
             _upload_images(mly_uploader, import_path, descs, stats)
 
         elif file_type == "blackvue":
+            video_paths = [
+                path
+                for path in utils.iterate_files(import_path)
+                if os.path.splitext(path)[1].lower() in [".mp4"]
+            ]
             _upload_blackvues(
                 mly_uploader,
-                utils.get_video_file_list(import_path, abs_path=True),
+                video_paths,
                 stats,
             )
 
         elif file_type == "zip":
+            zip_paths = [
+                path
+                for path in utils.iterate_files(import_path)
+                if os.path.splitext(path)[1].lower() in [".zip"]
+            ]
             _upload_zipfiles(
                 mly_uploader,
-                utils.get_zip_file_list(import_path, abs_path=True),
+                zip_paths,
                 stats,
             )
 

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -1,3 +1,4 @@
+import sys
 import io
 import json
 import uuid
@@ -11,6 +12,11 @@ import zipfile
 
 import requests
 import jsonschema
+
+if sys.version_info >= (3, 8):
+    from typing import Literal  # pylint: disable=no-name-in-module
+else:
+    from typing_extensions import Literal
 
 from . import upload_api_v4, types, exif_write, utils
 
@@ -68,19 +74,29 @@ class UploadCancelled(Exception):
     pass
 
 
+EventName = Literal[
+    "upload_start",
+    "upload_fetch_offset",
+    "upload_progress",
+    "upload_end",
+    "upload_finished",
+    "upload_interrupted",
+]
+
+
 class EventEmitter:
-    events: T.Dict[str, T.List]
+    events: T.Dict[EventName, T.List]
 
     def __init__(self):
         self.events = {}
 
-    def on(self, event: str):
+    def on(self, event: EventName):
         def _wrap(callback):
             self.events.setdefault(event, []).append(callback)
 
         return _wrap
 
-    def emit(self, event: str, *args, **kwargs):
+    def emit(self, event: EventName, *args, **kwargs):
         for callback in self.events.get(event, []):
             callback(*args, **kwargs)
 
@@ -94,37 +110,45 @@ class Uploader:
         self.dry_run = dry_run
         self.emitter = emitter
 
-    def upload_zipfile(self, zip_path: str) -> T.Optional[int]:
+    def upload_zipfile(
+        self, zip_path: str, event_payload: T.Optional[Progress] = None
+    ) -> T.Optional[int]:
         with zipfile.ZipFile(zip_path) as ziph:
             namelist = ziph.namelist()
 
         if not namelist:
             raise RuntimeError(f"The zip file {zip_path} is empty")
 
-        event_payload: Progress = {
+        if event_payload is None:
+            event_payload = T.cast(Progress, {})
+
+        new_event_payload: Progress = {
+            **event_payload,
             "import_path": zip_path,
-            "sequence_idx": 0,
             "sequence_image_count": len(namelist),
-            "total_sequence_count": 1,
         }
 
         with open(zip_path, "rb") as fp:
             try:
                 return _upload_zipfile_fp(
                     fp,
+                    len(namelist),
                     self.user_items,
-                    event_payload=event_payload,
+                    event_payload=new_event_payload,
                     emitter=self.emitter,
                     dry_run=self.dry_run,
                 )
             except UploadCancelled:
                 return None
 
-    def upload_blackvue(self, blackvue_path: str) -> T.Optional[int]:
+    def upload_blackvue(
+        self, blackvue_path: str, event_payload: T.Optional[Progress] = None
+    ) -> T.Optional[int]:
         try:
             return upload_blackvue(
                 blackvue_path,
                 self.user_items,
+                event_payload=event_payload,
                 emitter=self.emitter,
                 dry_run=self.dry_run,
             )
@@ -149,6 +173,7 @@ class Uploader:
                 try:
                     cluster_id: T.Optional[int] = _upload_zipfile_fp(
                         fp,
+                        len(images),
                         self.user_items,
                         emitter=self.emitter,
                         event_payload=event_payload,
@@ -225,6 +250,7 @@ def _zip_sequence_fp(
 
 def _upload_zipfile_fp(
     fp: T.IO[bytes],
+    image_count: int,
     user_items: types.UserItem,
     event_payload: T.Optional[Progress] = None,
     emitter: T.Optional[EventEmitter] = None,
@@ -243,9 +269,7 @@ def _upload_zipfile_fp(
     entity_size = fp.tell()
 
     # chunk size
-    avg_image_size = int(
-        entity_size / max(event_payload.get("sequence_image_count", 1), 1)
-    )
+    avg_image_size = int(entity_size / image_count)
     chunk_size = min(max(avg_image_size, MIN_CHUNK_SIZE), MAX_CHUNK_SIZE)
 
     if dry_run:
@@ -280,6 +304,7 @@ def _upload_zipfile_fp(
 def upload_blackvue(
     blackvue_path: str,
     user_items: types.UserItem,
+    event_payload: T.Optional[Progress] = None,
     emitter: EventEmitter = None,
     dry_run=False,
 ) -> int:
@@ -314,19 +339,21 @@ def upload_blackvue(
                 file_type="mly_blackvue_video",
             )
 
-        event_payload: Progress = {
+        if event_payload is None:
+            event_payload = T.cast(Progress, {})
+
+        new_event_payload: Progress = {
+            **event_payload,
             "entity_size": entity_size,
             "import_path": blackvue_path,
             "md5sum": upload_md5sum,
-            "sequence_idx": 0,
-            "total_sequence_count": 1,
         }
 
         return _upload_fp(
             upload_service,
             fp,
             chunk_size,
-            event_payload=event_payload,
+            event_payload=new_event_payload,
             emitter=emitter,
         )
 

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -120,10 +120,9 @@ class Uploader:
             raise RuntimeError(f"The zip file {zip_path} is empty")
 
         if event_payload is None:
-            event_payload = T.cast(Progress, {})
+            event_payload = {}
 
         new_event_payload: Progress = {
-            **event_payload,
             "import_path": zip_path,
             "sequence_image_count": len(namelist),
         }
@@ -134,7 +133,9 @@ class Uploader:
                     fp,
                     len(namelist),
                     self.user_items,
-                    event_payload=new_event_payload,
+                    event_payload=T.cast(
+                        Progress, {**event_payload, **new_event_payload}
+                    ),
                     emitter=self.emitter,
                     dry_run=self.dry_run,
                 )
@@ -340,10 +341,9 @@ def upload_blackvue(
             )
 
         if event_payload is None:
-            event_payload = T.cast(Progress, {})
+            event_payload = {}
 
         new_event_payload: Progress = {
-            **event_payload,
             "entity_size": entity_size,
             "import_path": blackvue_path,
             "md5sum": upload_md5sum,
@@ -353,7 +353,7 @@ def upload_blackvue(
             upload_service,
             fp,
             chunk_size,
-            event_payload=new_event_payload,
+            event_payload=T.cast(Progress, {**event_payload, **new_event_payload}),
             emitter=emitter,
         )
 

--- a/mapillary_tools/utils.py
+++ b/mapillary_tools/utils.py
@@ -55,17 +55,6 @@ def get_video_file_list(
     )
 
 
-def get_zip_file_list(
-    video_file: str, skip_subfolders: bool = False, abs_path: bool = False
-) -> T.List[str]:
-    files = iterate_files(video_file, not skip_subfolders)
-    return sorted(
-        file if abs_path else os.path.relpath(file, video_file)
-        for file in files
-        if os.path.splitext(file)[1] in [".zip"]
-    )
-
-
 def get_image_file_list(
     import_path: str, skip_subfolders: bool = False, abs_path: bool = False
 ) -> T.List[str]:

--- a/mapillary_tools/utils.py
+++ b/mapillary_tools/utils.py
@@ -25,12 +25,12 @@ def file_md5sum(path: str) -> str:
 
 
 def is_image_file(path: str) -> bool:
-    basename, ext = os.path.splitext(os.path.basename(path))
+    _, ext = os.path.splitext(os.path.basename(path))
     return ext.lower() in (".jpg", ".jpeg", ".tif", ".tiff", ".pgm", ".pnm")
 
 
 def is_video_file(path: str) -> bool:
-    basename, ext = os.path.splitext(os.path.basename(path))
+    _, ext = os.path.splitext(os.path.basename(path))
     return ext.lower() in (".mp4", ".avi", ".tavi", ".mov", ".mkv")
 
 
@@ -52,6 +52,17 @@ def get_video_file_list(
         file if abs_path else os.path.relpath(file, video_file)
         for file in files
         if is_video_file(file)
+    )
+
+
+def get_zip_file_list(
+    video_file: str, skip_subfolders: bool = False, abs_path: bool = False
+) -> T.List[str]:
+    files = iterate_files(video_file, not skip_subfolders)
+    return sorted(
+        file if abs_path else os.path.relpath(file, video_file)
+        for file in files
+        if os.path.splitext(file)[1] in [".zip"]
     )
 
 


### PR DESCRIPTION
The current "upload" command handle many cases and it is getting complicated:
```
- upload video1.mp4 video2.mp4
- upload mly_tools_xxx.zip mly_tools_yyy.zip
- upload image_folder1 image_folder2
```

When it comes to uploading a folder, "upload" doesn't know if it's a folder of images or a folder of blackvues.

This PR adds two separate commands "upload_blackvue" and "upload_zip", while let "upload" focus on uploading a single directory of images:
```
- upload_blackvue blackvue_folder blackvue.mp4
- upload_zip zip_folder mly_tools_xxx.zip
- upload image_dir
```