### PR TITLE
fix: off-by-one error in sbtl parsing

### DIFF
--- a/mapillary_tools/geotag/simple_mp4_parser.py
+++ b/mapillary_tools/geotag/simple_mp4_parser.py
@@ -420,13 +420,14 @@ def extract_raw_samples(
                 sample_idx += 1
             chunk_idx += 1
 
-    # If all the chunks have the same number of samples per chunk and use the same sample description, this table has one entry.
+    # If all the chunks have the same number of samples per chunk and use the same sample description,
+    # this table has one entry.
     while sample_idx < len(timedeltas):
+        sample_offset = chunk_offsets[chunk_idx]
         for _ in range(chunk_entries[-1].samples_per_chunk):
-            sample_offset = chunk_offsets[chunk_idx]
             is_sync = syncs is None or (sample_idx + 1) in syncs
             yield RawSample(
-                description_idx=chunk_entries[-1].sample_description_index - 1,
+                description_idx=chunk_entries[-1].sample_description_index,
                 offset=sample_offset,
                 size=sizes[sample_idx],
                 timedelta=timedeltas[sample_idx],

--- a/tests/unit/test_simple_mp4_builder.py
+++ b/tests/unit/test_simple_mp4_builder.py
@@ -238,6 +238,6 @@ def test_parse_raw_samples_from_stbl():
             "data": {"entries": [1, 2, 3, 3], "sample_count": 4, "sample_size": 0},
             "type": b"stsz",
         },
-        {"data": {"entries": [1, 5]}, "type": b"co64"},
+        {"data": {"entries": [1, 5]}, "type": b"stco"},
         {"data": {"entries": [1, 3]}, "type": b"stss"},
     ]


### PR DESCRIPTION
`sample.description_idx` should be always 1-based (same as the one parsed from `stsc`).