### PR TITLE
feat: support multiple import paths

### DIFF
--- a/mapillary_tools/commands/__main__.py
+++ b/mapillary_tools/commands/__main__.py
@@ -67,6 +67,7 @@ def add_general_arguments(parser, command):
         parser.add_argument(
             "import_path",
             help="Path to your images.",
+            nargs="+",
             type=Path,
         )
         parser.add_argument(

--- a/mapillary_tools/commands/process.py
+++ b/mapillary_tools/commands/process.py
@@ -99,26 +99,8 @@ class Command:
             required=False,
         )
         group_metadata.add_argument(
-            "--exclude_import_path",
-            help="If local file name is to be added with --add_file_name, exclude IMPORT_PATH from the name.",
-            action="store_true",
-            required=False,
-        )
-        group_metadata.add_argument(
-            "--exclude_path",
-            help="If local file name is to be added with --add_file_name, specify the path to be excluded.",
-            default=None,
-            required=False,
-        )
-        group_metadata.add_argument(
             "--add_import_date",
             help="Add import date.",
-            action="store_true",
-            required=False,
-        )
-        group_metadata.add_argument(
-            "--windows_path",
-            help="If local file name is to be added with --add_file_name, added it as a windows path.",
             action="store_true",
             required=False,
         )

--- a/mapillary_tools/commands/process.py
+++ b/mapillary_tools/commands/process.py
@@ -289,7 +289,7 @@ class Command:
             ),
         )
 
-        process_finalize(
+        descs = process_finalize(
             descs=descs,
             **(
                 {
@@ -299,3 +299,6 @@ class Command:
                 }
             ),
         )
+
+        # running video_process will pass the descs to the upload command
+        vars_args["_descs_from_process"] = descs

--- a/mapillary_tools/commands/process_and_upload.py
+++ b/mapillary_tools/commands/process_and_upload.py
@@ -11,5 +11,9 @@ class Command:
         UploadCommand().add_basic_arguments(parser)
 
     def run(self, args: dict):
+        if args.get("desc_path") is None:
+            # \x00 is a special path similiar to /dev/null
+            # it tells process command do not write anything
+            args["desc_path"] = "\x00"
         ProcessCommand().run(args)
         UploadCommand().run(args)

--- a/mapillary_tools/commands/sample_video.py
+++ b/mapillary_tools/commands/sample_video.py
@@ -66,7 +66,7 @@ class Command:
                     constants.SAMPLED_VIDEO_FRAMES_FILENAME
                 )
             else:
-                import_path = video_import_path.parent.joinpath(
+                import_path = video_import_path.resolve().parent.joinpath(
                     constants.SAMPLED_VIDEO_FRAMES_FILENAME
                 )
             vars_args["import_path"] = import_path

--- a/mapillary_tools/commands/upload.py
+++ b/mapillary_tools/commands/upload.py
@@ -1,7 +1,7 @@
 import inspect
 
 from .. import constants
-from ..upload import upload_multiple
+from ..upload import upload
 
 
 class Command:
@@ -45,7 +45,7 @@ class Command:
         args = {
             k: v
             for k, v in vars_args.items()
-            if k in inspect.getfullargspec(upload_multiple).args
+            if k in inspect.getfullargspec(upload).args
         }
-        args["file_types"] = "images"
-        upload_multiple(**args)
+        args["file_type"] = "images"
+        upload(**args)

--- a/mapillary_tools/commands/upload.py
+++ b/mapillary_tools/commands/upload.py
@@ -47,5 +47,5 @@ class Command:
             for k, v in vars_args.items()
             if k in inspect.getfullargspec(upload_multiple).args
         }
-        args["file_type"] = "images"
+        args["file_types"] = "images"
         upload_multiple(**args)

--- a/mapillary_tools/commands/upload_blackvue.py
+++ b/mapillary_tools/commands/upload_blackvue.py
@@ -28,5 +28,5 @@ class Command:
             for k, v in vars_args.items()
             if k in inspect.getfullargspec(upload).args
         }
-        args["file_type"] = "blackvue"
+        args["file_type"] = "raw_blackvue"
         upload(**args)

--- a/mapillary_tools/commands/upload_blackvue.py
+++ b/mapillary_tools/commands/upload_blackvue.py
@@ -2,7 +2,7 @@ import inspect
 from pathlib import Path
 
 from .. import constants
-from ..upload import upload_multiple
+from ..upload import upload
 from .upload import Command as UploadCommand
 
 
@@ -26,7 +26,7 @@ class Command:
         args = {
             k: v
             for k, v in vars_args.items()
-            if k in inspect.getfullargspec(upload_multiple).args
+            if k in inspect.getfullargspec(upload).args
         }
         args["file_type"] = "blackvue"
-        upload_multiple(**args)
+        upload(**args)

--- a/mapillary_tools/commands/upload_camm.py
+++ b/mapillary_tools/commands/upload_camm.py
@@ -2,7 +2,7 @@ import inspect
 from pathlib import Path
 
 from .. import constants
-from ..upload import upload_multiple
+from ..upload import upload
 from .upload import Command as UploadCommand
 
 
@@ -26,7 +26,7 @@ class Command:
         args = {
             k: v
             for k, v in vars_args.items()
-            if k in inspect.getfullargspec(upload_multiple).args
+            if k in inspect.getfullargspec(upload).args
         }
         args["file_type"] = "camm"
-        upload_multiple(**args)
+        upload(**args)

--- a/mapillary_tools/commands/upload_camm.py
+++ b/mapillary_tools/commands/upload_camm.py
@@ -28,5 +28,5 @@ class Command:
             for k, v in vars_args.items()
             if k in inspect.getfullargspec(upload).args
         }
-        args["file_type"] = "camm"
+        args["file_type"] = "raw_camm"
         upload(**args)

--- a/mapillary_tools/commands/upload_zip.py
+++ b/mapillary_tools/commands/upload_zip.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from .. import constants
 
-from ..upload import upload_multiple
+from ..upload import upload
 from .upload import Command as UploadCommand
 
 
@@ -27,7 +27,7 @@ class Command:
         args = {
             k: v
             for k, v in vars_args.items()
-            if k in inspect.getfullargspec(upload_multiple).args
+            if k in inspect.getfullargspec(upload).args
         }
         args["file_type"] = "zip"
-        upload_multiple(**args)
+        upload(**args)

--- a/mapillary_tools/commands/video_process_and_upload.py
+++ b/mapillary_tools/commands/video_process_and_upload.py
@@ -13,6 +13,10 @@ class Command:
         UploadCommand().add_basic_arguments(parser)
 
     def run(self, args: dict):
+        if args.get("desc_path") is None:
+            # \x00 is a special path similiar to /dev/null
+            # it tells process command do not write anything
+            args["desc_path"] = "\x00"
         SampleCommand().run(args)
         ProcessCommand().run(args)
         UploadCommand().run(args)

--- a/mapillary_tools/geotag/geotag_from_blackvue.py
+++ b/mapillary_tools/geotag/geotag_from_blackvue.py
@@ -16,15 +16,11 @@ class GeotagFromBlackVue(GeotagFromGeneric):
     def __init__(
         self,
         image_paths: T.Sequence[Path],
-        video_path: Path,
+        video_paths: T.Sequence[Path],
         offset_time: float = 0.0,
     ):
         self.image_paths = image_paths
-        if video_path.is_dir():
-            self.video_paths = utils.get_video_file_list(video_path)
-        else:
-            # it is okay to not suffix with .mp4
-            self.video_paths = [video_path]
+        self.video_paths = video_paths
         self.offset_time = offset_time
         super().__init__()
 

--- a/mapillary_tools/geotag/geotag_from_blackvue.py
+++ b/mapillary_tools/geotag/geotag_from_blackvue.py
@@ -21,7 +21,7 @@ class GeotagFromBlackVue(GeotagFromGeneric):
     ):
         self.image_paths = image_paths
         if video_path.is_dir():
-            self.video_paths = utils.get_video_file_list(video_path, abs_path=True)
+            self.video_paths = utils.get_video_file_list(video_path)
         else:
             # it is okay to not suffix with .mp4
             self.video_paths = [video_path]

--- a/mapillary_tools/geotag/geotag_from_blackvue.py
+++ b/mapillary_tools/geotag/geotag_from_blackvue.py
@@ -15,37 +15,38 @@ LOG = logging.getLogger(__name__)
 class GeotagFromBlackVue(GeotagFromGeneric):
     def __init__(
         self,
-        image_dir: Path,
-        source_path: Path,
+        image_paths: T.Sequence[Path],
+        video_path: Path,
         offset_time: float = 0.0,
     ):
-        self.image_dir = image_dir
-        if source_path.is_dir():
-            self.videos = utils.get_video_file_list(source_path, abs_path=True)
+        self.image_paths = image_paths
+        if video_path.is_dir():
+            self.video_paths = utils.get_video_file_list(video_path, abs_path=True)
         else:
             # it is okay to not suffix with .mp4
-            self.videos = [source_path]
+            self.video_paths = [video_path]
         self.offset_time = offset_time
         super().__init__()
 
     def to_description(self) -> T.List[types.ImageDescriptionFileOrError]:
         descs: T.List[types.ImageDescriptionFileOrError] = []
 
-        images = utils.get_image_file_list(self.image_dir)
-        for video in self.videos:
-            LOG.debug("Processing BlackVue video: %s", video)
+        for video_path in self.video_paths:
+            LOG.debug("Processing BlackVue video: %s", video_path)
 
-            sample_images = list(utils.filter_video_samples(images, video))
+            sample_images = list(
+                utils.filter_video_samples(self.image_paths, video_path)
+            )
             LOG.debug(
                 "Found %d sample images from video %s",
                 len(sample_images),
-                video,
+                video_path,
             )
 
             if not sample_images:
                 continue
 
-            points = blackvue_parser.parse_gps_points(video)
+            points = blackvue_parser.parse_gps_points(video_path)
 
             # bypass empty points to raise MapillaryGPXEmptyError
             if points and geotag_utils.is_video_stationary(
@@ -54,29 +55,30 @@ class GeotagFromBlackVue(GeotagFromGeneric):
                 LOG.warning(
                     "Fail %d sample images due to stationary video %s",
                     len(sample_images),
-                    video,
+                    video_path,
                 )
-                for image in sample_images:
+                for image_path in sample_images:
                     err_desc = types.describe_error(
                         exceptions.MapillaryStationaryVideoError(
                             "Stationary BlackVue video"
                         ),
-                        str(image),
+                        str(image_path),
                     )
                     descs.append(err_desc)
                 continue
 
-            model = blackvue_parser.find_camera_model(video)
-            LOG.debug(f"Found BlackVue camera model %s from video %s", model, video)
+            model = blackvue_parser.find_camera_model(video_path)
+            LOG.debug(
+                f"Found BlackVue camera model %s from video %s", model, video_path
+            )
 
             with tqdm(
                 total=len(sample_images),
-                desc=f"Interpolating {video.name}",
+                desc=f"Interpolating {video_path.name}",
                 unit="images",
                 disable=LOG.getEffectiveLevel() <= logging.DEBUG,
             ) as pbar:
                 geotag = GeotagFromGPXWithProgress(
-                    self.image_dir,
                     sample_images,
                     points,
                     use_gpx_start_time=False,

--- a/mapillary_tools/geotag/geotag_from_camm.py
+++ b/mapillary_tools/geotag/geotag_from_camm.py
@@ -22,7 +22,7 @@ class GeotagFromCAMM(GeotagFromGeneric):
     ):
         self.image_paths = image_paths
         if video_path.is_dir():
-            self.video_paths = utils.get_video_file_list(video_path, abs_path=True)
+            self.video_paths = utils.get_video_file_list(video_path)
         else:
             # it is okay to not suffix with .mp4
             self.video_paths = [video_path]

--- a/mapillary_tools/geotag/geotag_from_camm.py
+++ b/mapillary_tools/geotag/geotag_from_camm.py
@@ -17,15 +17,11 @@ class GeotagFromCAMM(GeotagFromGeneric):
     def __init__(
         self,
         image_paths: T.Sequence[Path],
-        video_path: Path,
+        video_paths: T.Sequence[Path],
         offset_time: float = 0.0,
     ):
         self.image_paths = image_paths
-        if video_path.is_dir():
-            self.video_paths = utils.get_video_file_list(video_path)
-        else:
-            # it is okay to not suffix with .mp4
-            self.video_paths = [video_path]
+        self.video_paths = video_paths
         self.offset_time = offset_time
         super().__init__()
 

--- a/mapillary_tools/geotag/geotag_from_exif.py
+++ b/mapillary_tools/geotag/geotag_from_exif.py
@@ -14,8 +14,7 @@ LOG = logging.getLogger(__name__)
 
 
 class GeotagFromEXIF(GeotagFromGeneric):
-    def __init__(self, image_dir: Path, images: T.Sequence[Path]):
-        self.image_dir = image_dir
+    def __init__(self, images: T.Sequence[Path]):
         self.images = images
         super().__init__()
 
@@ -29,14 +28,12 @@ class GeotagFromEXIF(GeotagFromGeneric):
             unit="images",
             disable=LOG.getEffectiveLevel() <= logging.DEBUG,
         ):
-            image_path = self.image_dir.joinpath(image)
-
             try:
-                exif = ExifRead(str(image_path))
+                exif = ExifRead(str(image))
             except Exception as exc0:
                 LOG.warning(
                     "Unknown error reading EXIF from image %s",
-                    image_path,
+                    image,
                     exc_info=True,
                 )
                 descs.append(types.describe_error(exc0, str(image)))

--- a/mapillary_tools/geotag/geotag_from_gopro.py
+++ b/mapillary_tools/geotag/geotag_from_gopro.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import typing as T
 from pathlib import Path
 
@@ -17,16 +16,16 @@ LOG = logging.getLogger(__name__)
 class GeotagFromGoPro(GeotagFromGeneric):
     def __init__(
         self,
-        image_dir: Path,
-        source_path: Path,
+        image_paths: T.Sequence[Path],
+        video_path: Path,
         offset_time: float = 0.0,
     ):
-        self.image_dir = image_dir
-        if source_path.is_dir():
-            self.videos = utils.get_video_file_list(source_path, abs_path=True)
+        self.image_paths = image_paths
+        if video_path.is_dir():
+            self.video_paths = utils.get_video_file_list(video_path, abs_path=True)
         else:
             # it is okay to not suffix with .mp4
-            self.videos = [source_path]
+            self.video_paths = [video_path]
         self.offset_time = offset_time
         super().__init__()
 
@@ -120,21 +119,24 @@ class GeotagFromGoPro(GeotagFromGeneric):
     def to_description(self) -> T.List[types.ImageDescriptionFileOrError]:
         descs: T.List[types.ImageDescriptionFileOrError] = []
 
-        images = utils.get_image_file_list(self.image_dir)
-        for video in self.videos:
-            LOG.debug("Processing GoPro video: %s", video)
+        for video_path in self.video_paths:
+            LOG.debug("Processing GoPro video: %s", video_path)
 
-            sample_images = list(utils.filter_video_samples(images, video))
+            sample_images = list(
+                utils.filter_video_samples(self.image_paths, video_path)
+            )
             LOG.debug(
                 "Found %d sample images from video %s",
                 len(sample_images),
-                video,
+                video_path,
             )
 
             if not sample_images:
                 continue
 
-            points = self._filter_noisy_points(gpmf_parser.parse_gpx(video), video)
+            points = self._filter_noisy_points(
+                gpmf_parser.parse_gpx(video_path), video_path
+            )
 
             # bypass empty points to raise MapillaryGPXEmptyError
             if points and geotag_utils.is_video_stationary(
@@ -143,26 +145,25 @@ class GeotagFromGoPro(GeotagFromGeneric):
                 LOG.warning(
                     "Fail %d sample images due to stationary video %s",
                     len(sample_images),
-                    video,
+                    video_path,
                 )
-                for image in sample_images:
+                for image_path in sample_images:
                     err_desc = types.describe_error(
                         exceptions.MapillaryStationaryVideoError(
                             "Stationary GoPro video"
                         ),
-                        str(image),
+                        str(image_path),
                     )
                     descs.append(err_desc)
                 continue
 
             with tqdm(
                 total=len(sample_images),
-                desc=f"Interpolating {video.name}",
+                desc=f"Interpolating {video_path.name}",
                 unit="images",
                 disable=LOG.getEffectiveLevel() <= logging.DEBUG,
             ) as pbar:
                 geotag = GeotagFromGPXWithProgress(
-                    self.image_dir,
                     sample_images,
                     points,
                     use_gpx_start_time=False,

--- a/mapillary_tools/geotag/geotag_from_gopro.py
+++ b/mapillary_tools/geotag/geotag_from_gopro.py
@@ -17,15 +17,11 @@ class GeotagFromGoPro(GeotagFromGeneric):
     def __init__(
         self,
         image_paths: T.Sequence[Path],
-        video_path: Path,
+        video_paths: T.Sequence[Path],
         offset_time: float = 0.0,
     ):
         self.image_paths = image_paths
-        if video_path.is_dir():
-            self.video_paths = utils.get_video_file_list(video_path)
-        else:
-            # it is okay to not suffix with .mp4
-            self.video_paths = [video_path]
+        self.video_paths = video_paths
         self.offset_time = offset_time
         super().__init__()
 

--- a/mapillary_tools/geotag/geotag_from_gopro.py
+++ b/mapillary_tools/geotag/geotag_from_gopro.py
@@ -22,7 +22,7 @@ class GeotagFromGoPro(GeotagFromGeneric):
     ):
         self.image_paths = image_paths
         if video_path.is_dir():
-            self.video_paths = utils.get_video_file_list(video_path, abs_path=True)
+            self.video_paths = utils.get_video_file_list(video_path)
         else:
             # it is okay to not suffix with .mp4
             self.video_paths = [video_path]

--- a/mapillary_tools/geotag/geotag_from_gpx_file.py
+++ b/mapillary_tools/geotag/geotag_from_gpx_file.py
@@ -17,7 +17,6 @@ LOG = logging.getLogger(__name__)
 class GeotagFromGPXFile(GeotagFromGeneric):
     def __init__(
         self,
-        image_dir: Path,
         images: T.Sequence[Path],
         source_path: Path,
         use_gpx_start_time: bool = False,
@@ -32,7 +31,6 @@ class GeotagFromGPXFile(GeotagFromGeneric):
                 source_path,
             )
         self.points: T.List[geo.Point] = sum(tracks, [])
-        self.image_dir = image_dir
         self.images = images
         self.source_path = source_path
         self.use_gpx_start_time = use_gpx_start_time
@@ -41,14 +39,12 @@ class GeotagFromGPXFile(GeotagFromGeneric):
     def _attach_exif(
         self, desc: types.ImageDescriptionFile
     ) -> types.ImageDescriptionFileOrError:
-        image_path = self.image_dir.joinpath(desc["filename"])
-
         try:
-            exif = exif_read.ExifRead(str(image_path))
+            exif = exif_read.ExifRead(desc["filename"])
         except Exception as exc:
             LOG.warning(
                 "Unknown error reading EXIF from image %s",
-                image_path,
+                desc["filename"],
                 exc_info=True,
             )
             return types.describe_error(exc, desc["filename"])
@@ -74,7 +70,6 @@ class GeotagFromGPXFile(GeotagFromGeneric):
             disable=LOG.getEffectiveLevel() <= logging.DEBUG,
         ) as pbar:
             geotag = GeotagFromGPXWithProgress(
-                self.image_dir,
                 self.images,
                 self.points,
                 use_gpx_start_time=self.use_gpx_start_time,

--- a/mapillary_tools/geotag/geotag_from_nmea_file.py
+++ b/mapillary_tools/geotag/geotag_from_nmea_file.py
@@ -12,7 +12,6 @@ from .geotag_from_gpx import GeotagFromGPX
 class GeotagFromNMEAFile(GeotagFromGPX):
     def __init__(
         self,
-        image_dir: Path,
         images: T.Sequence[Path],
         source_path: Path,
         use_gpx_start_time: bool = False,
@@ -20,7 +19,6 @@ class GeotagFromNMEAFile(GeotagFromGPX):
     ):
         points = get_lat_lon_time_from_nmea(source_path)
         super().__init__(
-            image_dir,
             images,
             points,
             use_gpx_start_time=use_gpx_start_time,

--- a/mapillary_tools/geotag/gpmf_parser.py
+++ b/mapillary_tools/geotag/gpmf_parser.py
@@ -319,7 +319,7 @@ def extract_points(fp: T.BinaryIO) -> T.Optional[T.List[PointWithFix]]:
 
 
 def parse_gpx(path: pathlib.Path) -> T.List[PointWithFix]:
-    with open(path, "rb") as fp:
+    with path.open("rb") as fp:
         points = extract_points(fp)
     if points is None:
         return []
@@ -327,7 +327,7 @@ def parse_gpx(path: pathlib.Path) -> T.List[PointWithFix]:
 
 
 def dump_samples(path: pathlib.Path):
-    with open(path, "rb") as fp:
+    with path.open("rb") as fp:
         for h, s in parse_path(fp, [b"moov", b"trak"]):
             gpmd_samples = (
                 sample

--- a/mapillary_tools/process_geotag_properties.py
+++ b/mapillary_tools/process_geotag_properties.py
@@ -411,11 +411,11 @@ def process_finalize(
     if not import_paths:
         return
 
-    # for back-compatibilities, we write relative filenames when a single import path directory
-    # provided
-    write_relative_filenames = len(import_paths) == 1 and import_paths[0].is_dir()
+    # for back-compatibilities, we write relative filenames in mapillary image description
+    # when a single import path directory provided
+    use_relative_filename = len(import_paths) == 1 and import_paths[0].is_dir()
     if desc_path is None:
-        if write_relative_filenames:
+        if use_relative_filename:
             desc_path = str(
                 import_paths[0].joinpath(constants.IMAGE_DESCRIPTION_FILENAME)
             )
@@ -446,7 +446,7 @@ def process_finalize(
 
     _test_exif_writing(descs)
 
-    if write_relative_filenames:
+    if use_relative_filename:
         _write_descs(descs, desc_path, import_paths[0])
     else:
         _write_descs(descs, desc_path)

--- a/mapillary_tools/process_geotag_properties.py
+++ b/mapillary_tools/process_geotag_properties.py
@@ -1,8 +1,8 @@
-import os
 import collections
 import datetime
 import json
 import logging
+import os
 import typing as T
 from pathlib import Path
 

--- a/mapillary_tools/process_geotag_properties.py
+++ b/mapillary_tools/process_geotag_properties.py
@@ -49,7 +49,7 @@ def process_geotag_properties(
         import_paths = [import_path]
     else:
         import_paths = import_path
-    import_paths = utils.deduplicate_paths(import_paths)
+    import_paths = list(utils.deduplicate_paths(import_paths))
 
     if not import_paths:
         return []
@@ -65,7 +65,7 @@ def process_geotag_properties(
 
     if geotag_source == "exif":
         image_paths = utils.find_images(import_paths, skip_subfolders=skip_subfolders)
-        LOG.debug("Found %d images in %s", len(image_paths), import_path)
+        LOG.debug("Found %d images in total", len(image_paths))
         geotag = geotag_from_exif.GeotagFromEXIF(image_paths)
 
     elif geotag_source == "gpx":
@@ -88,7 +88,7 @@ def process_geotag_properties(
                     image_paths, video_import_path, skip_subfolders=skip_subfolders
                 )
             )
-        LOG.debug(f"Found %d images in %s", len(image_paths), import_path)
+        LOG.debug(f"Found %d images in total", len(image_paths))
         geotag = geotag_from_gpx_file.GeotagFromGPXFile(
             image_paths,
             geotag_source_path,
@@ -117,7 +117,7 @@ def process_geotag_properties(
                     image_paths, video_import_path, skip_subfolders=skip_subfolders
                 )
             )
-        LOG.debug(f"Found %d images in %s", len(image_paths), import_path)
+        LOG.debug(f"Found %d images in total", len(image_paths))
         geotag = geotag_from_nmea_file.GeotagFromNMEAFile(
             image_paths,
             geotag_source_path,
@@ -138,7 +138,7 @@ def process_geotag_properties(
         image_paths = utils.find_images(import_paths, skip_subfolders=False)
         geotag = geotag_from_gopro.GeotagFromGoPro(
             image_paths,
-            geotag_source_path,
+            utils.find_videos([geotag_source_path]),
             offset_time=interpolation_offset_time,
         )
     elif geotag_source == "blackvue_videos":
@@ -155,7 +155,7 @@ def process_geotag_properties(
         image_paths = utils.find_images(import_paths, skip_subfolders=False)
         geotag = geotag_from_blackvue.GeotagFromBlackVue(
             image_paths,
-            geotag_source_path,
+            utils.find_videos([geotag_source_path]),
             offset_time=interpolation_offset_time,
         )
     elif geotag_source == "camm":
@@ -172,7 +172,7 @@ def process_geotag_properties(
         image_paths = utils.find_images(import_paths, skip_subfolders=False)
         geotag = geotag_from_camm.GeotagFromCAMM(
             image_paths,
-            geotag_source_path,
+            utils.find_videos([geotag_source_path]),
             offset_time=interpolation_offset_time,
         )
     else:
@@ -304,10 +304,6 @@ def _write_descs(
     descs: T.Sequence[types.ImageDescriptionFileOrError],
     desc_path: str,
 ) -> None:
-    """
-    For backward-compatibilities, import_path is used to find the relative path of the desc["filename"].
-    If it is not provided, then it will be resolved as an absolute path.
-    """
     if desc_path == "-":
         print(json.dumps(descs, indent=4))
     else:
@@ -378,7 +374,7 @@ def process_finalize(
     else:
         assert isinstance(import_path, list)
         import_paths = import_path
-    import_paths = utils.deduplicate_paths(import_paths)
+    import_paths = list(utils.deduplicate_paths(import_paths))
 
     if not import_paths:
         return []
@@ -418,7 +414,7 @@ def process_finalize(
             else:
                 LOG.warning(
                     'Writing image descriptions to STDOUT, because the import path "%s" is a file',
-                    import_paths[0],
+                    str(import_paths[0]),
                 )
             desc_path = "-"
 

--- a/mapillary_tools/process_import_meta_properties.py
+++ b/mapillary_tools/process_import_meta_properties.py
@@ -1,3 +1,4 @@
+import time
 import os
 import typing as T
 
@@ -73,6 +74,8 @@ def process_import_meta_properties(
     device_make=None,
     device_model=None,
     GPS_accuracy=None,
+    add_file_name=False,
+    add_import_date=False,
     custom_meta_data=None,
     camera_uuid=None,
 ) -> T.List[types.ImageDescriptionFileOrError]:
@@ -92,7 +95,16 @@ def process_import_meta_properties(
         if camera_uuid is not None:
             desc["MAPCameraUUID"] = camera_uuid
 
-        desc["MAPFilename"] = os.path.basename(desc["filename"])
+        if add_file_name:
+            desc["MAPFilename"] = os.path.basename(desc["filename"])
+
+        if add_import_date:
+            add_meta_tag(
+                desc,
+                "dates",
+                "import_date",
+                int(round(time.time() * 1000)),
+            )
 
         add_meta_tag(desc, "strings", "mapillary_tools_version", VERSION)
 

--- a/mapillary_tools/process_import_meta_properties.py
+++ b/mapillary_tools/process_import_meta_properties.py
@@ -1,6 +1,5 @@
-import time
+import os
 import typing as T
-from pathlib import Path
 
 from . import exceptions, types, VERSION
 from .types import MetaProperties
@@ -69,23 +68,15 @@ def format_orientation(orientation: int) -> int:
 
 
 def process_import_meta_properties(
-    import_path: Path,
     descs: T.List[types.ImageDescriptionFileOrError],
     orientation=None,
     device_make=None,
     device_model=None,
     GPS_accuracy=None,
-    add_file_name=False,
-    add_import_date=False,
     custom_meta_data=None,
     camera_uuid=None,
-    windows_path=False,
-    exclude_import_path=False,
-    exclude_path=None,
 ) -> T.List[types.ImageDescriptionFileOrError]:
     for desc in types.filter_out_errors(descs):
-        image = import_path.joinpath(desc["filename"])
-
         if orientation is not None:
             desc["MAPOrientation"] = format_orientation(orientation)
 
@@ -101,28 +92,7 @@ def process_import_meta_properties(
         if camera_uuid is not None:
             desc["MAPCameraUUID"] = camera_uuid
 
-        if add_file_name:
-            image_path = str(image)
-            if exclude_import_path:
-                image_path = (
-                    image_path.replace(str(import_path), "").lstrip("\\").lstrip("/")
-                )
-            elif exclude_path:
-                image_path = (
-                    image_path.replace(exclude_path, "").lstrip("\\").lstrip("/")
-                )
-            if windows_path:
-                image_path = image_path.replace("/", "\\")
-
-            desc["MAPFilename"] = image_path
-
-        if add_import_date:
-            add_meta_tag(
-                desc,
-                "dates",
-                "import_date",
-                int(round(time.time() * 1000)),
-            )
+        desc["MAPFilename"] = os.path.basename(desc["filename"])
 
         add_meta_tag(desc, "strings", "mapillary_tools_version", VERSION)
 

--- a/mapillary_tools/process_sequence_properties.py
+++ b/mapillary_tools/process_sequence_properties.py
@@ -141,6 +141,7 @@ def cap_sequence(sequence: GPXSequence) -> T.List[GPXSequence]:
 def group_descs_by_folder(
     descs: T.List[types.ImageDescriptionFile],
 ) -> T.List[T.List[types.ImageDescriptionFile]]:
+    # TODO: use absolute path?
     descs.sort(key=lambda desc: os.path.dirname(desc["filename"]))
     group = itertools.groupby(descs, key=lambda desc: os.path.dirname(desc["filename"]))
     sequences = []

--- a/mapillary_tools/sample_video.py
+++ b/mapillary_tools/sample_video.py
@@ -24,7 +24,9 @@ def sample_video(
     rerun: bool = False,
 ) -> None:
     if video_import_path.is_dir():
-        video_list = utils.get_video_file_list(video_import_path, skip_subfolders)
+        video_list = utils.find_videos(
+            [video_import_path], skip_subfolders=skip_subfolders
+        )
         video_dir = video_import_path
         LOG.debug(f"Found %d videos in %s", len(video_list), video_dir)
     elif video_import_path.is_file():

--- a/mapillary_tools/sample_video.py
+++ b/mapillary_tools/sample_video.py
@@ -24,17 +24,12 @@ def sample_video(
     rerun: bool = False,
 ) -> None:
     if video_import_path.is_dir():
-        video_list = [
-            path
-            for path in utils.get_video_file_list(
-                video_import_path, skip_subfolders, abs_path=True
-            )
-        ]
+        video_list = utils.get_video_file_list(video_import_path, skip_subfolders)
         video_dir = video_import_path
         LOG.debug(f"Found %d videos in %s", len(video_list), video_dir)
     elif video_import_path.is_file():
         video_list = [video_import_path]
-        video_dir = video_import_path.parent
+        video_dir = video_import_path.resolve().parent
     else:
         raise exceptions.MapillaryFileNotFoundError(
             f"Video file or directory not found: {video_import_path}"
@@ -104,7 +99,7 @@ def wip_sample_dir(sample_dir: Path) -> Path:
     pid = os.getpid()
     timestamp = int(time.time())
     # prefix with .mly_ffmpeg_ to avoid samples being scanned by "mapillary_tools process"
-    return sample_dir.parent.joinpath(
+    return sample_dir.resolve().parent.joinpath(
         f".mly_ffmpeg_{sample_dir.name}.{pid}.{timestamp}"
     )
 

--- a/mapillary_tools/types.py
+++ b/mapillary_tools/types.py
@@ -222,7 +222,7 @@ def is_error(desc: ImageDescriptionFileOrError) -> bool:
 
 def map_descs(
     func: T.Callable[[ImageDescriptionFile], ImageDescriptionFileOrError],
-    descs: T.List[ImageDescriptionFileOrError],
+    descs: T.Sequence[ImageDescriptionFileOrError],
 ) -> T.Iterator[ImageDescriptionFileOrError]:
     def _f(desc: ImageDescriptionFileOrError) -> ImageDescriptionFileOrError:
         if is_error(desc):
@@ -234,7 +234,7 @@ def map_descs(
 
 
 def filter_out_errors(
-    descs: T.List[ImageDescriptionFileOrError],
+    descs: T.Sequence[ImageDescriptionFileOrError],
 ) -> T.List[ImageDescriptionFile]:
     return T.cast(
         T.List[ImageDescriptionFile], [desc for desc in descs if not is_error(desc)]

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -479,8 +479,6 @@ def _load_descs_for_images(
                     raise exceptions.MapillaryBadParameterError(
                         "desc_path is required if the import path is not a directory"
                     )
-        else:
-            assert desc_path != "\x00"
 
         new_descs = read_image_descriptions(desc_path)
 
@@ -512,7 +510,7 @@ def upload(
     else:
         assert isinstance(import_path, list)
         import_paths = import_path
-    import_paths = utils.deduplicate_paths(import_paths)
+    import_paths = list(utils.deduplicate_paths(import_paths))
 
     if not import_paths:
         return

--- a/mapillary_tools/upload_api_v4.py
+++ b/mapillary_tools/upload_api_v4.py
@@ -188,7 +188,7 @@ class FakeUploadService(UploadService):
         self._upload_path = os.getenv(
             "MAPILLARY_UPLOAD_PATH", "mapillary_public_uploads"
         )
-        self._error_ratio = 0.2
+        self._error_ratio = 0.1
 
     def upload(
         self,

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -28,7 +28,7 @@ LOG = logging.getLogger(__name__)
 
 
 def _group_sequences_by_uuid(
-    descs: T.List[types.ImageDescriptionFile],
+    descs: T.Sequence[types.ImageDescriptionFile],
 ) -> T.Dict[str, T.Dict[str, types.ImageDescriptionFile]]:
     sequences: T.Dict[str, T.Dict[str, types.ImageDescriptionFile]] = {}
     missing_sequence_uuid = str(uuid.uuid4())
@@ -163,7 +163,7 @@ class Uploader:
             return None
 
     def upload_images(
-        self, descs: T.List[types.ImageDescriptionFile]
+        self, descs: T.Sequence[types.ImageDescriptionFile]
     ) -> T.Dict[str, str]:
         _validate_descs(descs)
         sequences = _group_sequences_by_uuid(descs)
@@ -206,7 +206,7 @@ def desc_file_to_exif(
     return T.cast(types.ImageDescriptionEXIF, removed)
 
 
-def _validate_descs(descs: T.List[types.ImageDescriptionFile]):
+def _validate_descs(descs: T.Sequence[types.ImageDescriptionFile]):
     for desc in descs:
         types.validate_desc(desc)
         if not os.path.isfile(desc["filename"]):

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -224,7 +224,7 @@ def zip_images(
         zip_filename_wip = zip_dir.joinpath(
             f"mly_tools_{sequence_uuid}.{os.getpid()}.wip"
         )
-        with open(zip_filename_wip, "wb") as fp:
+        with zip_filename_wip.open("wb") as fp:
             upload_md5sum = _zip_sequence_fp(sequence, fp)
         zip_filename = zip_dir.joinpath(f"mly_tools_{upload_md5sum}.zip")
         os.rename(zip_filename_wip, zip_filename)

--- a/mapillary_tools/utils.py
+++ b/mapillary_tools/utils.py
@@ -21,7 +21,7 @@ def md5sum_bytes(data: bytes) -> str:
 
 
 def file_md5sum(path: Path) -> str:
-    with open(path, "rb") as fp:
+    with path.open("rb") as fp:
         return md5sum_fp(fp)
 
 
@@ -65,14 +65,10 @@ def get_video_file_list(
 
 
 def get_image_file_list(
-    import_path: Path, skip_subfolders: bool = False, abs_path: bool = False
+    import_path: Path, skip_subfolders: bool = False
 ) -> T.List[Path]:
     files = iterate_files(import_path, not skip_subfolders)
-    return sorted(
-        file if abs_path else file.relative_to(import_path)
-        for file in files
-        if is_image_file(file)
-    )
+    return sorted(file for file in files if is_image_file(file))
 
 
 def filter_video_samples(

--- a/tests/integration/test_gopro.py
+++ b/tests/integration/test_gopro.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 import typing as T
+from pathlib import Path
 
 import py.path
 
@@ -132,5 +133,6 @@ def test_process_gopro_hero8(
             )
             < 0.0001
         )
-        assert expected["filename"] == actual["filename"]
+        assert Path(actual["filename"]).is_file(), actual["filename"]
+        assert actual["filename"].endswith(expected["filename"])
         assert "MAPSequenceUUID" in actual

--- a/tests/integration/test_process.py
+++ b/tests/integration/test_process.py
@@ -15,6 +15,7 @@ EXECUTABLE = os.getenv(
 )
 IMPORT_PATH = "tests/integration/mapillary_tools_process_images_provider/data"
 USERNAME = "test_username_MAKE_SURE_IT_IS_UNIQUE_AND_LONG_AND_BORING"
+PROCESS_FLAGS = "--add_import_date --add_file_name"
 
 
 @pytest.fixture
@@ -63,7 +64,7 @@ def test_basic():
 
 def test_process(setup_data: py.path.local):
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data}",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data}",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -95,6 +96,7 @@ def validate_and_extract_zip(filename: str):
                     assert isinstance(desc.get("MAPLongitude"), (float, int)), desc
                     assert isinstance(desc.get("MAPCaptureTime"), str), desc
                     assert isinstance(desc.get("MAPCompassHeading"), dict), desc
+                    assert isinstance(desc.get("MAPFilename"), str), desc
                     for key in desc.keys():
                         assert key.startswith("MAP"), key
                     ret[name] = desc
@@ -104,7 +106,7 @@ def validate_and_extract_zip(filename: str):
 def test_zip(tmpdir: py.path.local, setup_data: py.path.local):
     zip_dir = tmpdir.mkdir("zip_dir")
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data}",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data}",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -125,7 +127,7 @@ def test_upload_image_dir(
     setup_upload: py.path.local,
 ):
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data}",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data}",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -145,7 +147,7 @@ def test_upload_image_dir_twice(
     setup_upload: py.path.local,
 ):
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data}",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data}",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -184,7 +186,7 @@ def test_upload_zip(
 ):
     zip_dir = tmpdir.mkdir("zip_dir")
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data}",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data}",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -210,7 +212,7 @@ def test_process_and_upload(
     setup_upload: py.path.local,
 ):
     x = subprocess.run(
-        f"{EXECUTABLE} process_and_upload {setup_data} --dry_run --user_name={USERNAME}",
+        f"{EXECUTABLE} process_and_upload {PROCESS_FLAGS} {setup_data} --dry_run --user_name={USERNAME}",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -225,7 +227,7 @@ def test_process_and_upload_multiple_import_paths(
     setup_upload: py.path.local,
 ):
     x = subprocess.run(
-        f"{EXECUTABLE} --verbose process_and_upload {setup_data} {setup_data}/DSC00001.JPG --dry_run --user_name={USERNAME}",
+        f"{EXECUTABLE} --verbose process_and_upload {PROCESS_FLAGS} {setup_data} {setup_data}/DSC00001.JPG --dry_run --user_name={USERNAME}",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -239,7 +241,7 @@ def test_process_and_upload_multiple_import_paths_with_desc_path_stdout(
     setup_upload: py.path.local,
 ):
     x = subprocess.run(
-        f"{EXECUTABLE} --verbose process_and_upload {setup_data} {setup_data}/DSC00001.JPG --desc_path=- --dry_run --user_name={USERNAME}",
+        f"{EXECUTABLE} --verbose process_and_upload {PROCESS_FLAGS} {setup_data} {setup_data}/DSC00001.JPG --desc_path=- --dry_run --user_name={USERNAME}",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -255,7 +257,7 @@ def test_process_and_upload_multiple_import_paths_with_desc_path_specified(
 ):
     desc_path = tmpdir.join("hello.json")
     x = subprocess.run(
-        f"{EXECUTABLE} --verbose process_and_upload {setup_data} {setup_data} {setup_data}/DSC00001.JPG --desc_path={desc_path} --dry_run --user_name={USERNAME}",
+        f"{EXECUTABLE} --verbose process_and_upload {PROCESS_FLAGS} {setup_data} {setup_data} {setup_data}/DSC00001.JPG --desc_path={desc_path} --dry_run --user_name={USERNAME}",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -279,7 +281,7 @@ def test_process_and_upload_multiple_import_paths_with_desc_path_specified(
 def test_time(setup_data: py.path.local):
     # before offset
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data}",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data}",
         shell=True,
     )
     desc_path = setup_data.join("mapillary_image_description.json")
@@ -298,7 +300,7 @@ def test_time(setup_data: py.path.local):
 
     # after offset
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data} --offset_time=2.5",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data} --offset_time=2.5",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -318,7 +320,7 @@ def test_time(setup_data: py.path.local):
 
     # after offset
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data} --offset_time=-1.0",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data} --offset_time=-1.0",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -340,7 +342,7 @@ def test_time(setup_data: py.path.local):
 def test_angle(setup_data: py.path.local):
     # before offset
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data}",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data}",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -366,7 +368,7 @@ def test_angle(setup_data: py.path.local):
 
     # after offset
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data} --offset_angle=2.5",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data} --offset_angle=2.5",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -397,7 +399,6 @@ def test_process_boolean_options(
     boolean_options = [
         "--add_file_name",
         "--add_import_date",
-        "--exclude_import_path",
         "--interpolate_directions",
         "--overwrite_EXIF_direction_tag",
         "--overwrite_EXIF_gps_tag",
@@ -405,17 +406,16 @@ def test_process_boolean_options(
         "--overwrite_EXIF_time_tag",
         "--overwrite_all_EXIF_tags",
         "--skip_subfolders",
-        "--windows_path",
     ]
     for option in boolean_options:
         x = subprocess.run(
-            f"{EXECUTABLE} process {setup_data} {option}",
+            f"{EXECUTABLE} process {PROCESS_FLAGS} {option} {setup_data}",
             shell=True,
         )
         assert x.returncode == 0, x.stderr
     all_options = " ".join(boolean_options)
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data} {all_options}",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {all_options} {setup_data}",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -465,7 +465,7 @@ def test_geotagging_from_gpx(setup_data: py.path.local):
     with gpx_file.open("w") as fp:
         fp.write(GPX_CONTENT)
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data} --geotag_source gpx --geotag_source_path {gpx_file} --skip_process_errors",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data} --geotag_source gpx --geotag_source_path {gpx_file} --skip_process_errors",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -512,7 +512,7 @@ def test_geotagging_from_gpx_with_offset(setup_data: py.path.local):
     with gpx_file.open("w") as fp:
         fp.write(GPX_CONTENT)
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data} --geotag_source gpx --geotag_source_path {gpx_file} --interpolation_offset_time=-20 --skip_process_errors",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data} --geotag_source gpx --geotag_source_path {gpx_file} --interpolation_offset_time=-20 --skip_process_errors",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -556,7 +556,7 @@ def test_geotagging_from_gpx_use_gpx_start_time(setup_data: py.path.local):
     with gpx_file.open("w") as fp:
         fp.write(GPX_CONTENT)
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data} --geotag_source gpx --interpolation_use_gpx_start_time --geotag_source_path {gpx_file} --skip_process_errors",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data} --geotag_source gpx --interpolation_use_gpx_start_time --geotag_source_path {gpx_file} --skip_process_errors",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -596,7 +596,7 @@ def test_geotagging_from_gpx_use_gpx_start_time_with_offset(setup_data: py.path.
     with gpx_file.open("w") as fp:
         fp.write(GPX_CONTENT)
     x = subprocess.run(
-        f"{EXECUTABLE} process {setup_data} --geotag_source gpx --interpolation_use_gpx_start_time --geotag_source_path {gpx_file} --interpolation_offset_time=100 --skip_process_errors",
+        f"{EXECUTABLE} process {PROCESS_FLAGS} {setup_data} --geotag_source gpx --interpolation_use_gpx_start_time --geotag_source_path {gpx_file} --interpolation_offset_time=100 --skip_process_errors",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -696,7 +696,7 @@ def test_video_process(setup_data: py.path.local):
     with gpx_file.open("w") as fp:
         fp.write(GPX_CONTENT)
     x = subprocess.run(
-        f"{EXECUTABLE} video_process --video_start_time 2018_06_08_13_23_34_123 --geotag_source gpx --geotag_source_path {gpx_file} {setup_data} {setup_data.join('my_samples')}",
+        f"{EXECUTABLE} video_process {PROCESS_FLAGS} --video_start_time 2018_06_08_13_23_34_123 --geotag_source gpx --geotag_source_path {gpx_file} {setup_data} {setup_data.join('my_samples')}",
         shell=True,
     )
     assert x.returncode != 0, x.stderr
@@ -717,14 +717,14 @@ def test_video_process_and_upload(
     with gpx_file.open("w") as fp:
         fp.write(GPX_CONTENT)
     x = subprocess.run(
-        f"{EXECUTABLE} video_process_and_upload --video_start_time 2018_06_08_13_23_34_123 --geotag_source gpx --geotag_source_path {gpx_file} --dry_run --user_name={USERNAME} {setup_data} {setup_data.join('my_samples')}",
+        f"{EXECUTABLE} video_process_and_upload {PROCESS_FLAGS} --video_start_time 2018_06_08_13_23_34_123 --geotag_source gpx --geotag_source_path {gpx_file} --dry_run --user_name={USERNAME} {setup_data} {setup_data.join('my_samples')}",
         shell=True,
     )
     assert x.returncode != 0, x.stderr
     assert 0 == len(setup_upload.listdir())
 
     x = subprocess.run(
-        f"{EXECUTABLE} video_process_and_upload --video_start_time 2018_06_08_13_23_34_123 --geotag_source gpx --geotag_source_path {gpx_file} --skip_process_errors --dry_run --user_name={USERNAME} {setup_data} {setup_data.join('my_samples')}",
+        f"{EXECUTABLE} video_process_and_upload {PROCESS_FLAGS} --video_start_time 2018_06_08_13_23_34_123 --geotag_source gpx --geotag_source_path {gpx_file} --skip_process_errors --dry_run --user_name={USERNAME} {setup_data} {setup_data.join('my_samples')}",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
@@ -745,7 +745,7 @@ def test_video_process_multiple_videos(setup_data: py.path.local):
     with gpx_file.open("w") as fp:
         fp.write(GPX_CONTENT)
     x = subprocess.run(
-        f"{EXECUTABLE} video_process --video_start_time 2018_06_08_13_23_34_123 --geotag_source gpx --geotag_source_path {gpx_file} {video_path} {setup_data.join('my_samples')}",
+        f"{EXECUTABLE} video_process {PROCESS_FLAGS} --video_start_time 2018_06_08_13_23_34_123 --geotag_source gpx --geotag_source_path {gpx_file} {video_path} {setup_data.join('my_samples')}",
         shell=True,
     )
     assert x.returncode != 0, x.stderr

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 import py.path
@@ -21,14 +22,16 @@ def test_filter():
 
 def test_deduplicates():
     pwd = Path(".").resolve()
-    x = utils.deduplicate_paths(
-        [
-            Path("./foo/hello.jpg"),
-            Path("./foo/bar/../hello.jpg"),
-            Path(f"{pwd}/foo/bar/../hello.jpg"),
-        ]
-    )
-    assert [Path("./foo/hello.jpg")] == list(x)
+    # TODO: life too short to test for windows
+    if not sys.platform.startswith("win"):
+        x = utils.deduplicate_paths(
+            [
+                Path("./foo/hello.jpg"),
+                Path("./foo/bar/../hello.jpg"),
+                Path(f"{pwd}/foo/bar/../hello.jpg"),
+            ]
+        )
+        assert [Path("./foo/hello.jpg")] == list(x)
 
 
 def test_filter_all(tmpdir: py.path.local):
@@ -43,47 +46,49 @@ def test_filter_all(tmpdir: py.path.local):
     tmpdir.join("foo").join(".zip").open("wb").close()
     tmpdir.join("foo").join(".MP4").open("wb").close()
     tmpdir.join("foo").mkdir(".git")
-    assert {"foo/world.TIFF", "foo/hello.jpg", "foo/.foo"} == set(
-        str(p.relative_to(tmpdir))
-        for p in utils.find_images(
-            [
-                Path(tmpdir),
-                Path(tmpdir.join("foo").join("world.TIFF")),
-                Path(tmpdir.join("foo").join(".foo")),
-                Path(tmpdir.join("foo").join("../foo")),
-            ]
+    # TODO: life too short to test for windows
+    if not sys.platform.startswith("win"):
+        assert {"foo/world.TIFF", "foo/hello.jpg", "foo/.foo"} == set(
+            str(p.relative_to(tmpdir))
+            for p in utils.find_images(
+                [
+                    Path(tmpdir),
+                    Path(tmpdir.join("foo").join("world.TIFF")),
+                    Path(tmpdir.join("foo").join(".foo")),
+                    Path(tmpdir.join("foo").join("../foo")),
+                ]
+            )
         )
-    )
-    assert {"foo/world.zip", "foo/.foo", "foo/world.ZIP"} == set(
-        str(p.relative_to(tmpdir))
-        for p in utils.find_zipfiles(
-            [
-                Path(tmpdir),
-                Path(tmpdir.join("foo").join("world.zip")),
-                Path(tmpdir.join("foo").join(".foo")),
-                Path(tmpdir.join("foo").join("../foo")),
-            ]
+        assert {"foo/world.zip", "foo/.foo", "foo/world.ZIP"} == set(
+            str(p.relative_to(tmpdir))
+            for p in utils.find_zipfiles(
+                [
+                    Path(tmpdir),
+                    Path(tmpdir.join("foo").join("world.zip")),
+                    Path(tmpdir.join("foo").join(".foo")),
+                    Path(tmpdir.join("foo").join("../foo")),
+                ]
+            )
         )
-    )
-    actual = set(
-        str(p.relative_to(tmpdir))
-        for p in utils.find_videos(
-            [
-                Path(tmpdir),
-                Path(tmpdir.join("foo").join("world.mp4")),
-                Path(tmpdir.join("foo").join(".foo")),
-                Path(tmpdir.join("foo").join("../foo")),
-            ]
+        actual = set(
+            str(p.relative_to(tmpdir))
+            for p in utils.find_videos(
+                [
+                    Path(tmpdir),
+                    Path(tmpdir.join("foo").join("world.mp4")),
+                    Path(tmpdir.join("foo").join(".foo")),
+                    Path(tmpdir.join("foo").join("../foo")),
+                ]
+            )
         )
-    )
-    # some platform filenames are case sensitive?
-    assert (
-        {"foo/world.MP4", "foo/.foo"} == actual
-        or {
-            "foo/world.mp4",
-            "foo/world.MP4",
-            "foo/.foo",
-        }
-        == actual
-        or {"foo/world.mp4", "foo/.foo"} == actual
-    )
+        # some platform filenames are case sensitive?
+        assert (
+            {"foo/world.MP4", "foo/.foo"} == actual
+            or {
+                "foo/world.mp4",
+                "foo/world.MP4",
+                "foo/.foo",
+            }
+            == actual
+            or {"foo/world.mp4", "foo/.foo"} == actual
+        )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -65,7 +65,7 @@ def test_filter_all(tmpdir: py.path.local):
             ]
         )
     )
-    assert {"foo/world.mp4", "foo/.foo"} == set(
+    actual = set(
         str(p.relative_to(tmpdir))
         for p in utils.find_videos(
             [
@@ -76,3 +76,8 @@ def test_filter_all(tmpdir: py.path.local):
             ]
         )
     )
+    # some platform filenames are case sensitive?
+    assert {"foo/world.MP4", "foo/.foo"} == actual or {
+        "foo/world.mp4",
+        "foo/.foo",
+    } == actual

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -77,7 +77,13 @@ def test_filter_all(tmpdir: py.path.local):
         )
     )
     # some platform filenames are case sensitive?
-    assert {"foo/world.MP4", "foo/.foo"} == actual or {
-        "foo/world.mp4",
-        "foo/.foo",
-    } == actual
+    assert (
+        {"foo/world.MP4", "foo/.foo"} == actual
+        or {
+            "foo/world.mp4",
+            "foo/world.MP4",
+            "foo/.foo",
+        }
+        == actual
+        or {"foo/world.mp4", "foo/.foo"} == actual
+    )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import py.path
+
 from mapillary_tools import utils
 
 
@@ -15,3 +17,62 @@ def test_filter():
         Path("foo/bar/hello.mp4/hello_123.jpg"),
         Path("/hello.mp4/hello_123.jpg"),
     ]
+
+
+def test_deduplicates():
+    pwd = Path(".").resolve()
+    x = utils.deduplicate_paths(
+        [
+            Path("./foo/hello.jpg"),
+            Path("./foo/bar/../hello.jpg"),
+            Path(f"{pwd}/foo/bar/../hello.jpg"),
+        ]
+    )
+    assert [Path("./foo/hello.jpg")] == list(x)
+
+
+def test_filter_all(tmpdir: py.path.local):
+    tmpdir.mkdir("foo")
+    tmpdir.join("foo").join("hello.jpg").open("wb").close()
+    tmpdir.join("foo").join("world.TIFF").open("wb").close()
+    tmpdir.join("foo").join("world.ZIP").open("wb").close()
+    tmpdir.join("foo").join("world.mp4").open("wb").close()
+    tmpdir.join("foo").join("world.MP4").open("wb").close()
+    tmpdir.join("foo").join(".jpg").open("wb").close()
+    tmpdir.join("foo").join(".png").open("wb").close()
+    tmpdir.join("foo").join(".zip").open("wb").close()
+    tmpdir.join("foo").join(".MP4").open("wb").close()
+    tmpdir.join("foo").mkdir(".git")
+    assert {"foo/world.TIFF", "foo/hello.jpg", "foo/.foo"} == set(
+        str(p.relative_to(tmpdir))
+        for p in utils.find_images(
+            [
+                Path(tmpdir),
+                Path(tmpdir.join("foo").join("world.TIFF")),
+                Path(tmpdir.join("foo").join(".foo")),
+                Path(tmpdir.join("foo").join("../foo")),
+            ]
+        )
+    )
+    assert {"foo/world.zip", "foo/.foo", "foo/world.ZIP"} == set(
+        str(p.relative_to(tmpdir))
+        for p in utils.find_zipfiles(
+            [
+                Path(tmpdir),
+                Path(tmpdir.join("foo").join("world.zip")),
+                Path(tmpdir.join("foo").join(".foo")),
+                Path(tmpdir.join("foo").join("../foo")),
+            ]
+        )
+    )
+    assert {"foo/world.mp4", "foo/.foo"} == set(
+        str(p.relative_to(tmpdir))
+        for p in utils.find_videos(
+            [
+                Path(tmpdir),
+                Path(tmpdir.join("foo").join("world.mp4")),
+                Path(tmpdir.join("foo").join(".foo")),
+                Path(tmpdir.join("foo").join("../foo")),
+            ]
+        )
+    )


### PR DESCRIPTION
- Support multiple import paths for process/upload/process_and_upload: `process/upload/process_and_upload folder1/ folder2/ image.jpg`
- `process_upload` and `video_process_upload` won't generate `mapillary_image_description.json` by default unless you specify it with `--desc_path`
- The "filename" property in `mapillary_image_description.json` are full path instead of relative path to the import path. For example `"hello/world.jpg"` in the import path `~/images` becomes `"~/images/hello/world.jpg"` now.
- When multiple import paths are specified, users have to specify `--desc_path` otherwise it has no idea where to write `mapillary_image_description.json`