### PR TITLE
feat: add on-the-fly CAMM video conversion to the upload command

### DIFF
--- a/mapillary_tools/commands/upload.py
+++ b/mapillary_tools/commands/upload.py
@@ -1,7 +1,7 @@
 import inspect
 
 from .. import constants
-from ..upload import upload, FileType
+from ..upload import FileType, upload
 
 
 class Command:

--- a/mapillary_tools/commands/upload.py
+++ b/mapillary_tools/commands/upload.py
@@ -1,7 +1,7 @@
 import inspect
 
 from .. import constants
-from ..upload import upload
+from ..upload import upload, FileType
 
 
 class Command:
@@ -34,6 +34,13 @@ class Command:
             f"{constants.ANSI_BOLD}UPLOAD OPTIONS{constants.ANSI_RESET_ALL}"
         )
         group.add_argument(
+            "--file_types",
+            help=f"Upload files of the specified types only. Supported file types: {','.join(sorted(t.value for t in FileType))} [default: %(default)s]",
+            type=lambda option: set(FileType(t) for t in option.split(",")),
+            default=FileType.IMAGE.value,
+            required=False,
+        )
+        group.add_argument(
             "--desc_path",
             help=f'Path to the image description file. If it is "-", then read from STDIN. Only works for uploading image directories. [default: {{IMPORT_PATH}}/{constants.IMAGE_DESCRIPTION_FILENAME}]',
             default=None,
@@ -47,5 +54,4 @@ class Command:
             for k, v in vars_args.items()
             if k in inspect.getfullargspec(upload).args
         }
-        args["file_type"] = "images"
         upload(**args)

--- a/mapillary_tools/commands/upload_blackvue.py
+++ b/mapillary_tools/commands/upload_blackvue.py
@@ -1,7 +1,7 @@
 import inspect
 from pathlib import Path
 
-from .. import constants
+from .. import constants, utils
 from ..upload import upload
 from .upload import Command as UploadCommand
 
@@ -28,5 +28,7 @@ class Command:
             for k, v in vars_args.items()
             if k in inspect.getfullargspec(upload).args
         }
-        args["file_type"] = "raw_blackvue"
-        upload(**args)
+        upload(
+            **args,
+            file_types={utils.FileType.RAW_BLACKVUE},
+        )

--- a/mapillary_tools/commands/upload_camm.py
+++ b/mapillary_tools/commands/upload_camm.py
@@ -1,7 +1,7 @@
 import inspect
 from pathlib import Path
 
-from .. import constants
+from .. import constants, utils
 from ..upload import upload
 from .upload import Command as UploadCommand
 
@@ -28,5 +28,7 @@ class Command:
             for k, v in vars_args.items()
             if k in inspect.getfullargspec(upload).args
         }
-        args["file_type"] = "raw_camm"
-        upload(**args)
+        upload(
+            **args,
+            file_types={utils.FileType.RAW_CAMM},
+        )

--- a/mapillary_tools/commands/upload_zip.py
+++ b/mapillary_tools/commands/upload_zip.py
@@ -1,7 +1,7 @@
 import inspect
 from pathlib import Path
 
-from .. import constants
+from .. import constants, utils
 
 from ..upload import upload
 from .upload import Command as UploadCommand
@@ -29,5 +29,7 @@ class Command:
             for k, v in vars_args.items()
             if k in inspect.getfullargspec(upload).args
         }
-        args["file_type"] = "zip"
-        upload(**args)
+        upload(
+            **args,
+            file_types={utils.FileType.ZIP},
+        )

--- a/mapillary_tools/geotag/geotag_from_camm.py
+++ b/mapillary_tools/geotag/geotag_from_camm.py
@@ -30,16 +30,16 @@ class GeotagFromCAMM(GeotagFromGeneric):
         for video_path in self.video_paths:
             LOG.debug("Processing CAMM video: %s", video_path)
 
-            sample_images = list(
+            sample_image_paths = list(
                 utils.filter_video_samples(self.image_paths, video_path)
             )
             LOG.debug(
                 "Found %d sample images from video %s",
-                len(sample_images),
+                len(sample_image_paths),
                 video_path,
             )
 
-            if not sample_images:
+            if not sample_image_paths:
                 continue
 
             points = camm_parser.parse_gpx(video_path)
@@ -50,10 +50,10 @@ class GeotagFromCAMM(GeotagFromGeneric):
             ):
                 LOG.warning(
                     "Fail %d sample images due to stationary video %s",
-                    len(sample_images),
+                    len(sample_image_paths),
                     video_path,
                 )
-                for image_path in sample_images:
+                for image_path in sample_image_paths:
                     err_desc = types.describe_error(
                         exceptions.MapillaryStationaryVideoError(
                             "Stationary CAMM video"
@@ -64,13 +64,13 @@ class GeotagFromCAMM(GeotagFromGeneric):
                 continue
 
             with tqdm(
-                total=len(sample_images),
+                total=len(sample_image_paths),
                 desc=f"Interpolating {video_path.name}",
                 unit="images",
                 disable=LOG.getEffectiveLevel() <= logging.DEBUG,
             ) as pbar:
                 geotag = GeotagFromGPXWithProgress(
-                    sample_images,
+                    sample_image_paths,
                     points,
                     use_gpx_start_time=False,
                     use_image_start_time=True,

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -28,15 +28,15 @@ from . import (
     uploader,
     utils,
 )
-from .utils import FileType
 from .geo import get_max_distance_from_start
 from .geotag import (
     blackvue_parser,
     camm_builder,
     camm_parser,
-    utils as video_utils,
     simple_mp4_builder,
+    utils as video_utils,
 )
+from .utils import FileType
 
 JSONDict = T.Dict[str, T.Union[str, int, float, None]]
 
@@ -614,7 +614,9 @@ def upload(
                 for d in (descs or [])
                 if Path(d["filename"]).resolve() in resolved_image_paths
             ]
-            clusters = mly_uploader.upload_images(specified_descs)
+            clusters = mly_uploader.upload_images(
+                specified_descs, event_payload={"file_type": FileType.IMAGE.value}
+            )
             LOG.debug(f"Uploaded to cluster: %s", clusters)
 
         supported = CAMM_CONVERTABLES.intersection(file_types)

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import logging
 import os
@@ -27,10 +28,16 @@ from . import (
     uploader,
     utils,
 )
+from .utils import FileType
 from .geo import get_max_distance_from_start
-from .geotag import blackvue_parser, camm_parser, utils as video_utils
+from .geotag import (
+    blackvue_parser,
+    camm_builder,
+    camm_parser,
+    utils as video_utils,
+    simple_mp4_builder,
+)
 
-FileType = Literal["raw_blackvue", "images", "zip", "raw_camm"]
 JSONDict = T.Dict[str, T.Union[str, int, float, None]]
 
 LOG = logging.getLogger(__name__)
@@ -46,6 +53,13 @@ MAPILLARY_UPLOAD_HISTORY_PATH = os.getenv(
         "upload_history",
     ),
 )
+CAMM_CONVERTABLES = {FileType.CAMM, FileType.BLACKVUE, FileType.GOPRO}
+
+
+class UploadError(Exception):
+    def __init__(self, inner_ex) -> None:
+        self.inner_ex = inner_ex
+        super().__init__(str(inner_ex))
 
 
 def read_image_descriptions(desc_path: str) -> T.List[types.ImageDescriptionFile]:
@@ -381,31 +395,45 @@ def _summarize(stats: T.Sequence[_APIStats]) -> T.Dict:
     return upload_summary
 
 
-def _show_upload_summary(summary: T.Dict, file_type: FileType):
-    if file_type == "images":
-        LOG.info(
-            "%8d  sequences (%d images) uploaded",
-            summary["sequences"],
-            summary["images"],
-        )
-    elif file_type == "raw_blackvue":
-        LOG.info(
-            "%8d  BlackVue videos uploaded",
-            summary["sequences"],
-        )
-    elif file_type == "raw_camm":
-        LOG.info(
-            "%8d  CAMM videos uploaded",
-            summary["sequences"],
-        )
-    elif file_type == "zip":
-        LOG.info(
-            "%8d  ZIP files uploaded",
-            summary["sequences"],
-        )
-    else:
-        assert False, f"unknown file_type: {file_type}"
+def _show_upload_summary(stats: T.Sequence[_APIStats]):
+    grouped: T.Dict[str, T.List[_APIStats]] = {}
+    for stat in stats:
+        grouped.setdefault(stat["file_type"], []).append(stat)
 
+    for file_type, typed_stats in grouped.items():
+        if file_type == FileType.IMAGE.value:
+            LOG.info(
+                "%8d  image sequences uploaded",
+                len(typed_stats),
+            )
+        elif file_type == FileType.RAW_BLACKVUE.value:
+            LOG.info(
+                "%8d  BlackVue videos uploaded",
+                len(typed_stats),
+            )
+        elif file_type == FileType.RAW_CAMM.value:
+            LOG.info(
+                "%8d  CAMM videos uploaded",
+                len(typed_stats),
+            )
+        elif file_type == FileType.GOPRO.value:
+            LOG.info(
+                "%8d  GoPro videos uploaded",
+                len(typed_stats),
+            )
+        elif file_type == FileType.ZIP.value:
+            LOG.info(
+                "%8d  ZIP files uploaded",
+                len(typed_stats),
+            )
+        else:
+            LOG.info(
+                "%8d  %s files uploaded",
+                len(typed_stats),
+                file_type,
+            )
+
+    summary = _summarize(stats)
     LOG.info("%8.1fM data in total", summary["size"])
     LOG.info("%8.1fM data uploaded", summary["uploaded_size"])
     LOG.info("%8.1fs upload time", summary["time"])
@@ -494,7 +522,7 @@ def _load_descs_for_images(
 
 def upload(
     import_path: T.Union[Path, T.Sequence[Path]],
-    file_type: FileType,
+    file_types: T.Set[FileType],
     desc_path: T.Optional[str] = None,
     _descs_from_process: T.Optional[
         T.Sequence[types.ImageDescriptionFileOrError]
@@ -504,6 +532,17 @@ def upload(
     dry_run=False,
     skip_subfolders=False,
 ) -> None:
+    if FileType.RAW_BLACKVUE in file_types and FileType.BLACKVUE in file_types:
+        raise exceptions.MapillaryBadParameterError(
+            f"file_types should contain either {FileType.RAW_BLACKVUE.value} or {FileType.BLACKVUE.value}, not both",
+        )
+
+    if FileType.RAW_CAMM in file_types and FileType.CAMM in file_types:
+        raise exceptions.MapillaryBadParameterError(
+            f"File types should contain either {FileType.RAW_CAMM.value} or {FileType.CAMM.value}, not both",
+        )
+    file_types = set(file_types)
+
     import_paths: T.Sequence[Path]
     if isinstance(import_path, Path):
         import_paths = [import_path]
@@ -522,7 +561,7 @@ def upload(
                 f"Import file or directory not found: {path}"
             )
 
-    if file_type == "images":
+    if FileType.IMAGE in file_types:
         descs = _load_descs_for_images(_descs_from_process, desc_path, import_paths)
     else:
         descs = None
@@ -562,39 +601,72 @@ def upload(
 
     mly_uploader = uploader.Uploader(user_items, emitter=emitter, dry_run=dry_run)
 
-    if file_type == "images":
-        image_paths = utils.find_images(import_paths, skip_subfolders=skip_subfolders)
-        # find descs that match the image paths from the import paths
-        resolved_image_paths = set(p.resolve() for p in image_paths)
-        specified_descs = [
-            d
-            for d in (descs or [])
-            if Path(d["filename"]).resolve() in resolved_image_paths
-        ]
-        _upload_images(mly_uploader, specified_descs, stats)
+    image_paths = utils.find_images(import_paths, skip_subfolders=skip_subfolders)
+    video_paths = utils.find_videos(import_paths, skip_subfolders=skip_subfolders)
+    zip_paths = utils.find_zipfiles(import_paths, skip_subfolders=skip_subfolders)
 
-    elif file_type == "raw_blackvue":
-        video_paths = utils.find_videos(import_paths, skip_subfolders=skip_subfolders)
-        _upload_raw_blackvues(mly_uploader, video_paths, stats)
+    try:
+        if FileType.IMAGE in file_types:
+            # find descs that match the image paths from the import paths
+            resolved_image_paths = set(p.resolve() for p in image_paths)
+            specified_descs = [
+                d
+                for d in (descs or [])
+                if Path(d["filename"]).resolve() in resolved_image_paths
+            ]
+            clusters = mly_uploader.upload_images(specified_descs)
+            LOG.debug(f"Uploaded to cluster: %s", clusters)
 
-    elif file_type == "raw_camm":
-        video_paths = utils.find_videos(import_paths, skip_subfolders=skip_subfolders)
-        _upload_raw_camm(mly_uploader, video_paths, stats)
+        supported = CAMM_CONVERTABLES.intersection(file_types)
+        if supported:
+            _convert_and_upload_camm(mly_uploader, video_paths, supported)
 
-    elif file_type == "zip":
-        zip_paths = utils.find_zipfiles(import_paths, skip_subfolders=skip_subfolders)
-        _upload_zipfiles(mly_uploader, zip_paths, stats)
+        if FileType.RAW_BLACKVUE in file_types:
+            _upload_raw_blackvues(mly_uploader, video_paths)
 
-    else:
-        raise RuntimeError(f"Invalid file_type: {file_type}")
+        if FileType.RAW_CAMM in file_types:
+            _upload_raw_camm(mly_uploader, video_paths)
+
+        if FileType.ZIP in file_types:
+            _upload_zipfiles(mly_uploader, zip_paths)
+
+    except UploadError as ex:
+        if not dry_run:
+            _api_logging_failed(mly_uploader.user_items, _summarize(stats), ex.inner_ex)
+        raise ex
 
     if stats:
-        upload_summary = _summarize(stats)
         if not dry_run:
-            _api_logging_finished(user_items, upload_summary)
-        _show_upload_summary(upload_summary, file_type)
+            _api_logging_finished(user_items, _summarize(stats))
+        _show_upload_summary(stats)
     else:
         LOG.info("Nothing uploaded. Bye.")
+
+
+def _convert_and_upload_camm(
+    mly_uploader: uploader.Uploader,
+    video_paths: T.Sequence[Path],
+    file_types: T.Set[FileType],
+) -> None:
+    for idx, video_path in enumerate(video_paths):
+        with open(video_path, "rb") as fp:
+            file_type, points = camm_builder.extract_points(fp, file_types)
+            if file_type is None:
+                continue
+            generator = camm_builder.camm_sample_generator2(points)
+            camm_fp = simple_mp4_builder.transform_mp4(fp, generator)
+            event_payload: uploader.Progress = {
+                "total_sequence_count": len(video_paths),
+                "sequence_idx": idx,
+                "file_type": file_type.value,
+            }
+            try:
+                cluster_id = mly_uploader.upload_camm_fp(
+                    T.cast(T.BinaryIO, camm_fp), video_path, event_payload=event_payload
+                )
+            except Exception as ex:
+                raise UploadError(ex) from ex
+        LOG.debug(f"Uploaded to cluster: %s", cluster_id)
 
 
 def _check_blackvue(video_path: Path) -> None:
@@ -617,6 +689,32 @@ def _check_blackvue(video_path: Path) -> None:
         )
 
 
+def _upload_raw_blackvues(
+    mly_uploader: uploader.Uploader,
+    video_paths: T.Sequence[Path],
+) -> None:
+    for idx, video_path in enumerate(video_paths):
+        event_payload: uploader.Progress = {
+            "total_sequence_count": len(video_paths),
+            "sequence_idx": idx,
+            "file_type": FileType.RAW_BLACKVUE.value,
+        }
+
+        try:
+            _check_blackvue(video_path)
+        except Exception as ex:
+            LOG.warning(f"Skipping due to: %s", ex)
+            continue
+
+        try:
+            cluster_id = mly_uploader.upload_blackvue(
+                video_path, event_payload=event_payload
+            )
+        except Exception as ex:
+            raise UploadError(ex) from ex
+        LOG.debug(f"Uploaded to cluster: %s", cluster_id)
+
+
 def _check_camm(video_path: Path) -> None:
     # Skip in tests only because we don't have valid sample CAMM for tests
     if os.getenv("MAPILLARY__DISABLE_CAMM_CHECK") == "YES":
@@ -637,43 +735,15 @@ def _check_camm(video_path: Path) -> None:
         )
 
 
-def _upload_raw_blackvues(
-    mly_uploader: uploader.Uploader,
-    video_paths: T.Sequence[Path],
-    stats: T.Sequence[_APIStats],
-):
-    for idx, video_path in enumerate(video_paths):
-        event_payload: uploader.Progress = {
-            "total_sequence_count": len(video_paths),
-            "sequence_idx": idx,
-        }
-
-        try:
-            _check_blackvue(video_path)
-        except Exception as ex:
-            LOG.warning(f"Skipping due to: %s", ex)
-            continue
-
-        try:
-            cluster_id = mly_uploader.upload_blackvue(
-                video_path, event_payload=event_payload
-            )
-        except Exception as exc:
-            if not mly_uploader.dry_run:
-                _api_logging_failed(mly_uploader.user_items, _summarize(stats), exc)
-            raise
-        LOG.debug(f"Uploaded to cluster: %s", cluster_id)
-
-
 def _upload_raw_camm(
     mly_uploader: uploader.Uploader,
     video_paths: T.Sequence[Path],
-    stats: T.Sequence[_APIStats],
-):
+) -> None:
     for idx, video_path in enumerate(video_paths):
         event_payload: uploader.Progress = {
             "total_sequence_count": len(video_paths),
             "sequence_idx": idx,
+            "file_type": FileType.RAW_CAMM.value,
         }
         try:
             _check_camm(video_path)
@@ -684,45 +754,26 @@ def _upload_raw_camm(
             cluster_id = mly_uploader.upload_camm(
                 video_path, event_payload=event_payload
             )
-        except Exception as exc:
-            if not mly_uploader.dry_run:
-                _api_logging_failed(mly_uploader.user_items, _summarize(stats), exc)
-            raise
+        except Exception as ex:
+            raise UploadError(ex) from ex
         LOG.debug(f"Uploaded to cluster: %s", cluster_id)
 
 
 def _upload_zipfiles(
     mly_uploader: uploader.Uploader,
     zip_paths: T.Sequence[Path],
-    stats: T.Sequence[_APIStats],
-):
+) -> None:
     for idx, zip_path in enumerate(zip_paths):
         event_payload: uploader.Progress = {
             "total_sequence_count": len(zip_paths),
             "sequence_idx": idx,
+            "file_type": FileType.ZIP.value,
         }
         try:
             cluster_id = mly_uploader.upload_zipfile(
                 zip_path, event_payload=event_payload
             )
-        except Exception as exc:
-            if not mly_uploader.dry_run:
-                _api_logging_failed(mly_uploader.user_items, _summarize(stats), exc)
-            raise
+        except Exception as ex:
+            raise UploadError(ex) from ex
 
         LOG.debug(f"Uploaded to cluster: %s", cluster_id)
-
-
-def _upload_images(
-    mly_uploader: uploader.Uploader,
-    descs: T.Sequence[types.ImageDescriptionFile],
-    stats: T.Sequence[_APIStats],
-):
-    try:
-        clusters = mly_uploader.upload_images(descs)
-    except Exception as exc:
-        if not mly_uploader.dry_run:
-            _api_logging_failed(mly_uploader.user_items, _summarize(stats), exc)
-        raise
-
-    LOG.debug(f"Uploaded to cluster: %s", clusters)

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -43,6 +43,9 @@ class Progress(types.TypedDict, total=False):
     # The size of the chunk, in bytes, that has been uploaded in the last request
     chunk_size: int
 
+    # File type
+    file_type: str
+
     # How many bytes has been uploaded so far since "upload_start"
     offset: int
 
@@ -61,7 +64,7 @@ class Progress(types.TypedDict, total=False):
     # MAPSequenceUUID. It is only available for directory uploading
     sequence_uuid: str
 
-    # An "upload_interrupted" will increase it. Reset to 0 if if the chunk is uploaded
+    # An "upload_interrupted" will increase it. Reset to 0 if the chunk is uploaded
     retries: int
 
     # md5sum of the zipfile/BlackVue/CAMM in uploading
@@ -152,14 +155,16 @@ class Uploader:
         self, blackvue_path: Path, event_payload: T.Optional[Progress] = None
     ) -> T.Optional[str]:
         try:
-            return upload_video(
-                blackvue_path,
-                self.user_items,
-                "mly_blackvue_video",
-                event_payload=event_payload,
-                emitter=self.emitter,
-                dry_run=self.dry_run,
-            )
+            with blackvue_path.open("rb") as fp:
+                return _upload_video_fp(
+                    fp,
+                    blackvue_path,
+                    self.user_items,
+                    "mly_blackvue_video",
+                    event_payload=event_payload,
+                    emitter=self.emitter,
+                    dry_run=self.dry_run,
+                )
         except UploadCancelled:
             return None
 
@@ -167,7 +172,28 @@ class Uploader:
         self, camm_path: Path, event_payload: T.Optional[Progress] = None
     ) -> T.Optional[str]:
         try:
-            return upload_video(
+            with camm_path.open("rb") as fp:
+                return _upload_video_fp(
+                    fp,
+                    camm_path,
+                    self.user_items,
+                    "mly_camm_video",
+                    event_payload=event_payload,
+                    emitter=self.emitter,
+                    dry_run=self.dry_run,
+                )
+        except UploadCancelled:
+            return None
+
+    def upload_camm_fp(
+        self,
+        fp: T.IO[bytes],
+        camm_path: Path,
+        event_payload: T.Optional[Progress] = None,
+    ) -> T.Optional[str]:
+        try:
+            return _upload_video_fp(
+                fp,
                 camm_path,
                 self.user_items,
                 "mly_camm_video",
@@ -337,7 +363,8 @@ def _upload_zipfile_fp(
     )
 
 
-def upload_video(
+def _upload_video_fp(
+    fp: T.IO[bytes],
     video_path: Path,
     user_items: types.UserItem,
     file_type: upload_api_v4.FileType,
@@ -345,53 +372,48 @@ def upload_video(
     emitter: EventEmitter = None,
     dry_run=False,
 ) -> str:
-    jsonschema.validate(instance=user_items, schema=types.UserItemSchema)
+    upload_md5sum = utils.md5sum_fp(fp)
 
-    with video_path.open("rb") as fp:
-        upload_md5sum = utils.md5sum_fp(fp)
+    fp.seek(0, io.SEEK_END)
+    entity_size = fp.tell()
 
-        fp.seek(0, io.SEEK_END)
-        entity_size = fp.tell()
+    # chunk size
+    avg_image_size = entity_size
+    chunk_size = min(max(avg_image_size, MIN_CHUNK_SIZE), MAX_CHUNK_SIZE)
 
-        # chunk size
-        avg_image_size = entity_size
-        chunk_size = min(max(avg_image_size, MIN_CHUNK_SIZE), MAX_CHUNK_SIZE)
-
-        if dry_run:
-            upload_service: upload_api_v4.UploadService = (
-                upload_api_v4.FakeUploadService(
-                    user_access_token=user_items["user_upload_token"],
-                    session_key=f"mly_tools_{upload_md5sum}.mp4",
-                    entity_size=entity_size,
-                    organization_id=user_items.get("MAPOrganizationKey"),
-                    file_type=file_type,
-                )
-            )
-        else:
-            upload_service = upload_api_v4.UploadService(
-                user_access_token=user_items["user_upload_token"],
-                session_key=f"mly_tools_{upload_md5sum}.mp4",
-                entity_size=entity_size,
-                organization_id=user_items.get("MAPOrganizationKey"),
-                file_type=file_type,
-            )
-
-        if event_payload is None:
-            event_payload = {}
-
-        new_event_payload: Progress = {
-            "entity_size": entity_size,
-            "import_path": str(video_path),
-            "md5sum": upload_md5sum,
-        }
-
-        return _upload_fp(
-            upload_service,
-            fp,
-            chunk_size,
-            event_payload=T.cast(Progress, {**event_payload, **new_event_payload}),
-            emitter=emitter,
+    if dry_run:
+        upload_service: upload_api_v4.UploadService = upload_api_v4.FakeUploadService(
+            user_access_token=user_items["user_upload_token"],
+            session_key=f"mly_tools_{upload_md5sum}.mp4",
+            entity_size=entity_size,
+            organization_id=user_items.get("MAPOrganizationKey"),
+            file_type=file_type,
         )
+    else:
+        upload_service = upload_api_v4.UploadService(
+            user_access_token=user_items["user_upload_token"],
+            session_key=f"mly_tools_{upload_md5sum}.mp4",
+            entity_size=entity_size,
+            organization_id=user_items.get("MAPOrganizationKey"),
+            file_type=file_type,
+        )
+
+    if event_payload is None:
+        event_payload = {}
+
+    new_event_payload: Progress = {
+        "entity_size": entity_size,
+        "import_path": str(video_path),
+        "md5sum": upload_md5sum,
+    }
+
+    return _upload_fp(
+        upload_service,
+        fp,
+        chunk_size,
+        event_payload=T.cast(Progress, {**event_payload, **new_event_payload}),
+        emitter=emitter,
+    )
 
 
 def is_retriable_exception(ex: Exception):

--- a/mapillary_tools/utils.py
+++ b/mapillary_tools/utils.py
@@ -1,7 +1,18 @@
+import enum
 import hashlib
 import os
 import typing as T
 from pathlib import Path
+
+
+class FileType(enum.Enum):
+    BLACKVUE = "blackvue"
+    CAMM = "camm"
+    GOPRO = "gopro"
+    IMAGE = "image"
+    RAW_BLACKVUE = "raw_blackvue"
+    RAW_CAMM = "raw_camm"
+    ZIP = "zip"
 
 
 def md5sum_fp(fp: T.IO[bytes]) -> str:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+
 from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Add `--file_types` that allows on-the-fly CAMM conversion from other video formats:
```
mapillary_tools upload --file_types=blackvue,gopro,camm,image ~/MapillaryUploadData/ --dry_run
```