### PR TITLE
improve: increase upload chunk size to 16MB

### DIFF
--- a/mapillary_tools/constants.py
+++ b/mapillary_tools/constants.py
@@ -23,6 +23,7 @@ SAMPLED_VIDEO_FRAMES_FILENAME = os.getenv(
 )
 MAX_SEQUENCE_LENGTH = int(os.getenv(_ENV_PREFIX + "MAX_SEQUENCE_LENGTH", 500))
 USER_DATA_DIR = appdirs.user_data_dir(appname="mapillary_tools", appauthor="Mapillary")
+UPLOAD_CHUNK_SIZE_MB = float(os.getenv(_ENV_PREFIX + "UPLOAD_CHUNK_SIZE_MB", 16))
 
 # DoP value, the lower the better
 # See https://github.com/gopro/gpmf-parser#hero5-black-with-gps-enabled-adds

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -173,7 +173,8 @@ def test_upload_blackvue(tmpdir: py.path.local, setup_upload: py.path.local):
     blackvue_path = tmpdir.join("blackvue.mp4")
     with open(blackvue_path, "wb") as fp:
         fp.write(b"this is a fake video")
-    resp = mly_uploader.upload_blackvue(Path(blackvue_path))
+    with Path(blackvue_path).open("rb") as fp:
+        resp = mly_uploader.upload_blackvue_fp(fp)
     assert resp == "0"
     for mp4_path in setup_upload.listdir():
         basename = os.path.basename(mp4_path)


### PR DESCRIPTION
Fixes https://github.com/mapillary/mapillary_tools/issues/570

The upload chunk size affects the upload speed. Here is a rough upload speed comparison with different chunk sizes under the same network configuration:

```
❯ python3 -m tests.cli.upload_api_v4 empty_data foo16 --chunk_size=5
  0%|▏                           | 35.0M/29.0G [00:06<1:22:52, 6.26MB/s]

```

```
❯ python3 -m tests.cli.upload_api_v4 empty_data foo16 --chunk_size=16
  0%|▎                         | 80.0M/29.0G [00:08<50:45, 10.2MB/s]
```

```
❯ python3 -m tests.cli.upload_api_v4 empty_data foo16 --chunk_size=32

  1%|█                         | 250M/29.0G [00:04<38:43, 13.3MB/s]

```

This PR changes the default chunk size to 16MB and allows users to customize it with `MAPILLARY_TOOLS_UPLOAD_CHUNK_SIZE_MB`, an example:
```
❯ MAPILLARY_TOOLS_UPLOAD_CHUNK_SIZE_MB=1 mapillary_tools process_and_upload images
```