### PR TITLE
fix: immediate reties on HTTP 412

### DIFF
--- a/mapillary_tools/authenticate.py
+++ b/mapillary_tools/authenticate.py
@@ -12,10 +12,10 @@ LOG = logging.getLogger(__name__)
 
 
 def authenticate(
-    user_name: str = None,
-    user_email: str = None,
-    user_password: str = None,
-    jwt: str = None,
+    user_name: T.Optional[str] = None,
+    user_email: T.Optional[str] = None,
+    user_password: T.Optional[str] = None,
+    jwt: T.Optional[str] = None,
 ):
     if user_name:
         user_name = user_name.strip()
@@ -43,20 +43,6 @@ def authenticate(
     config.update_config(user_name, user_items)
 
 
-class HTTPError(requests.HTTPError):
-    pass
-
-
-def wrap_http_exception(ex: requests.HTTPError):
-    resp = ex.response
-    lines = [
-        f"{ex.request.method} {resp.url}",
-        f"> HTTP Status: {ex.response.status_code}",
-        f"{ex.response.text}",
-    ]
-    return HTTPError("\n".join(lines))
-
-
 def prompt_user_for_user_items(user_name: str) -> types.UserItem:
     print(f"Sign in for user {user_name}")
     user_email = input("Enter your Mapillary user email: ")
@@ -71,12 +57,12 @@ def prompt_user_for_user_items(user_name: str) -> types.UserItem:
             if subcode in [1348028, 1348092, 3404005, 1348131]:
                 title = r.get("error", {}).get("error_user_title")
                 message = r.get("error", {}).get("error_user_msg")
-                LOG.error(f"{title}: {message}")
+                LOG.error(f"%s: %s", title, message)
                 return prompt_user_for_user_items(user_name)
             else:
-                raise wrap_http_exception(ex)
+                raise ex
         else:
-            raise wrap_http_exception(ex)
+            raise ex
 
     data = resp.json()
     upload_token = T.cast(str, data.get("access_token"))

--- a/mapillary_tools/constants.py
+++ b/mapillary_tools/constants.py
@@ -32,6 +32,7 @@ GOPRO_MAX_DOP100 = int(os.getenv(_ENV_PREFIX + "GOPRO_MAX_DOP100", 1000))
 GOPRO_GPS_FIXES: T.Set[int] = set(
     int(fix) for fix in os.getenv(_ENV_PREFIX + "GOPRO_GPS_FIXES", "2,3").split(",")
 )
+MAX_UPLOAD_RETRIES: int = int(os.getenv(_ENV_PREFIX + "MAX_UPLOAD_RETRIES", 200))
 
 # GPS precision, in meters, is used to filter outliers
 GOPRO_GPS_PRECISION = float(os.getenv(_ENV_PREFIX + "GOPRO_GPS_PRECISION", 15))

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -63,6 +63,20 @@ class UploadError(Exception):
         super().__init__(str(inner_ex))
 
 
+class UploadHTTPError(Exception):
+    pass
+
+
+def wrap_http_exception(ex: requests.HTTPError):
+    resp = ex.response
+    lines = [
+        f"{ex.request.method} {resp.url}",
+        f"> HTTP Status: {ex.response.status_code}",
+        f"{ex.response.content}",
+    ]
+    return UploadHTTPError("\n".join(lines))
+
+
 def read_image_descriptions(desc_path: str) -> T.List[types.ImageDescriptionFile]:
     descs: T.List[types.ImageDescriptionFile] = []
 
@@ -137,7 +151,7 @@ def fetch_user_items(
                 user_items["user_upload_token"], organization_key
             )
         except requests.HTTPError as ex:
-            raise authenticate.wrap_http_exception(ex) from ex
+            raise wrap_http_exception(ex) from ex
         org = resp.json()
         LOG.info("Uploading to organization: %s", json.dumps(org))
         user_items = T.cast(
@@ -440,7 +454,7 @@ def _api_logging_finished(user_items: types.UserItem, summary: T.Dict):
         LOG.warning(
             "Error from API Logging for action %s",
             action,
-            exc_info=uploader.upload_api_v4.wrap_http_exception(exc),
+            exc_info=wrap_http_exception(exc),
         )
     except:
         LOG.warning("Error from API Logging for action %s", action, exc_info=True)
@@ -460,7 +474,7 @@ def _api_logging_failed(user_items: types.UserItem, payload: T.Dict, exc: Except
             payload_with_reason,
         )
     except requests.HTTPError as exc:
-        wrapped_exc = uploader.upload_api_v4.wrap_http_exception(exc)
+        wrapped_exc = wrap_http_exception(exc)
         LOG.warning(
             "Error from API Logging for action %s",
             action,
@@ -625,7 +639,10 @@ def upload(
     except UploadError as ex:
         if not dry_run:
             _api_logging_failed(mly_uploader.user_items, _summarize(stats), ex.inner_ex)
-        raise ex
+        if isinstance(ex.inner_ex, requests.HTTPError):
+            raise wrap_http_exception(ex.inner_ex) from ex.inner_ex
+        else:
+            raise ex
 
     if stats:
         if not dry_run:
@@ -686,6 +703,7 @@ def _convert_and_upload_camm(
                 )
             except Exception as ex:
                 raise UploadError(ex) from ex
+
         LOG.debug(f"Uploaded to cluster: %s", cluster_id)
 
 
@@ -782,6 +800,7 @@ def _upload_raw_camm(
                 )
         except Exception as ex:
             raise UploadError(ex) from ex
+
         LOG.debug(f"Uploaded to cluster: %s", cluster_id)
 
 

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -72,7 +72,7 @@ def wrap_http_exception(ex: requests.HTTPError):
     lines = [
         f"{ex.request.method} {resp.url}",
         f"> HTTP Status: {ex.response.status_code}",
-        f"{ex.response.content}",
+        f"{resp.content}",
     ]
     return UploadHTTPError("\n".join(lines))
 
@@ -143,7 +143,10 @@ def fetch_user_items(
                 f"Found multiple Mapillary accounts. Please specify one with --user_name"
             )
     else:
-        user_items = authenticate.authenticate_user(user_name)
+        try:
+            user_items = authenticate.authenticate_user(user_name)
+        except requests.HTTPError as exc:
+            raise wrap_http_exception(exc) from exc
 
     if organization_key is not None:
         try:

--- a/mapillary_tools/upload_api_v4.py
+++ b/mapillary_tools/upload_api_v4.py
@@ -33,20 +33,6 @@ UPLOAD_REQUESTS_TIMEOUT = (30 * 60, 30 * 60)  # 30 minutes
 FileType = Literal["zip", "mly_blackvue_video", "mly_camm_video"]
 
 
-class UploadHTTPError(Exception):
-    pass
-
-
-def wrap_http_exception(ex: requests.HTTPError):
-    resp = ex.response
-    lines = [
-        f"{ex.request.method} {resp.url}",
-        f"> HTTP Status: {ex.response.status_code}",
-        f"{ex.response.text}",
-    ]
-    return UploadHTTPError("\n".join(lines))
-
-
 def _sanitize_headers(headers: T.Dict):
     return {
         k: v

--- a/mapillary_tools/upload_api_v4.py
+++ b/mapillary_tools/upload_api_v4.py
@@ -163,7 +163,7 @@ class UploadService:
             return payload["h"]
         except KeyError:
             raise RuntimeError(
-                f"Upload server error: File handle not found in the upload response {resp.content}"
+                f"Upload server error: File handle not found in the upload response {resp.text}"
             )
 
     def finish(self, file_handle: str) -> str:
@@ -195,7 +195,7 @@ class UploadService:
         cluster_id = data.get("cluster_id")
         if cluster_id is None:
             raise RuntimeError(
-                f"Upload server error: failed to create the cluster {resp.content}"
+                f"Upload server error: failed to create the cluster {resp.text}"
             )
 
         return T.cast(str, cluster_id)

--- a/mapillary_tools/upload_api_v4.py
+++ b/mapillary_tools/upload_api_v4.py
@@ -163,7 +163,7 @@ class UploadService:
             return payload["h"]
         except KeyError:
             raise RuntimeError(
-                f"Upload server error: File handle not found in the upload response {resp.text}"
+                f"Upload server error: File handle not found in the upload response {resp.content}"
             )
 
     def finish(self, file_handle: str) -> str:
@@ -195,7 +195,7 @@ class UploadService:
         cluster_id = data.get("cluster_id")
         if cluster_id is None:
             raise RuntimeError(
-                f"Upload server error: failed to create the cluster {resp.text}"
+                f"Upload server error: failed to create the cluster {resp.content}"
             )
 
         return T.cast(str, cluster_id)

--- a/tests/cli/upload_api_v4.py
+++ b/tests/cli/upload_api_v4.py
@@ -9,14 +9,20 @@ import requests
 import tqdm
 from mapillary_tools import upload
 
-from mapillary_tools.upload_api_v4 import (
-    DEFAULT_CHUNK_SIZE,
-    UploadService,
-    wrap_http_exception,
-)
+from mapillary_tools.upload_api_v4 import DEFAULT_CHUNK_SIZE, UploadService
 
 
 LOG = logging.getLogger("mapillary_tools")
+
+
+def wrap_http_exception(ex: requests.HTTPError):
+    resp = ex.response
+    lines = [
+        f"{ex.request.method} {resp.url}",
+        f"> HTTP Status: {ex.response.status_code}",
+        f"{resp.content}",
+    ]
+    return Exception("\n".join(lines))
 
 
 def configure_logger(logger: logging.Logger, stream=None) -> None:


### PR DESCRIPTION
- retry immediately for HTTP 412
- add envvar `MAPILLARY_TOOLS_MAX_UPLOAD_RETRIES` to control number of retries
- remove wrap_http_exception from authenticate.py

https://github.com/mapillary/mapillary_tools/issues/569
