### PR TITLE
fix: parse and build ctts (Composition Time to Sample Box)

### DIFF
--- a/mapillary_tools/geotag/camm_builder.py
+++ b/mapillary_tools/geotag/camm_builder.py
@@ -106,6 +106,7 @@ def convert_points_to_raw_samples(
             offset=0,
             size=len(camm_sample_data),
             timedelta=timedelta,
+            composition_offset=0,
             is_sync=True,
         )
 

--- a/mapillary_tools/geotag/construct_mp4_parser.py
+++ b/mapillary_tools/geotag/construct_mp4_parser.py
@@ -576,3 +576,24 @@ MP4WithoutSTBLParserConstruct = Box64ConstructBuilder(MP4_WITHOUT_STBL_CMAP)
 # for building mp4 only
 MP4BuilderConstruct = Box32ConstructBuilder(MP4_CMAP, extend_eof=True)
 MP4WithoutSTBLBuilderConstruct = Box32ConstructBuilder(MP4_WITHOUT_STBL_CMAP)
+
+
+def find_box_at_pathx(
+    box: T.Union[T.Iterable[BoxDict], BoxDict], path: T.Sequence[bytes]
+) -> BoxDict:
+    if not path:
+        raise ValueError(f"box at path {path} not found")
+    boxes: T.Iterable[BoxDict]
+    if isinstance(box, dict):
+        boxes = [T.cast(BoxDict, box)]
+    else:
+        boxes = box
+    for box in boxes:
+        if box["type"] == path[0]:
+            if len(path) == 1:
+                return box
+            else:
+                return find_box_at_pathx(
+                    T.cast(T.Iterable[BoxDict], box["data"]), path[1:]
+                )
+    raise ValueError(f"box at path {path} not found")

--- a/mapillary_tools/geotag/construct_mp4_parser.py
+++ b/mapillary_tools/geotag/construct_mp4_parser.py
@@ -15,6 +15,7 @@ BoxType = Literal[
     b"@mak",
     b"@mod",
     b"co64",
+    b"ctts",
     b"dinf",
     b"dref",
     b"edts",
@@ -289,6 +290,27 @@ TimeToSampleBox = C.Struct(
     ),
 )
 
+# moov -> trak -> mdia -> minf -> stbl -> ctts
+# Box Type: ‘ctts’
+# Container: Sample Table Box (‘stbl’)
+# Mandatory: No
+# Quantity: Zero or one
+CompositionTimeToSampleBox = C.Struct(
+    "version" / C.Default(C.Int8ub, 0),
+    "flags" / C.Default(C.Int24ub, 0),
+    "entries"
+    / C.Default(
+        C.PrefixedArray(
+            C.Int32ub,
+            C.Struct(
+                "sample_count" / C.Int32ub,
+                "sample_offset" / C.Int32ub,
+            ),
+        ),
+        [],
+    ),
+)
+
 # moov -> trak -> mdia -> minf -> stbl -> stsc
 # Box Type: ‘stsc’
 # Container: Sample Table Box (‘stbl’)
@@ -458,6 +480,7 @@ CMAP: SwitchMapType = {
     b"mdhd": MediaHeaderBox,
     b"stsc": SampleToChunkBox,
     b"stts": TimeToSampleBox,
+    b"ctts": CompositionTimeToSampleBox,
     b"co64": ChunkLargeOffsetBox,
     b"stco": ChunkOffsetBox,
     b"stsd": SampleDescriptionBox,
@@ -475,6 +498,7 @@ CMAP: SwitchMapType = {
 CMAP[b"stbl"] = {
     b"stsd": CMAP[b"stsd"],
     b"stts": CMAP[b"stts"],
+    b"ctts": CMAP[b"ctts"],
     b"stsc": CMAP[b"stsc"],
     b"stsz": CMAP[b"stsz"],
     b"stco": CMAP[b"stco"],

--- a/mapillary_tools/geotag/simple_mp4_builder.py
+++ b/mapillary_tools/geotag/simple_mp4_builder.py
@@ -124,6 +124,31 @@ def _build_stts(sample_deltas: T.Iterable[int]) -> BoxDict:
     }
 
 
+@dataclasses.dataclass
+class _CompressedSampleCompositionOffset:
+    __slots__ = ("sample_count", "sample_offset")
+    # make sure dataclasses.asdict() produce the result as CompositionTimeToSampleBox expects
+    sample_count: int
+    sample_offset: int
+
+
+def _build_ctts(sample_composition_offsets: T.Iterable[int]) -> BoxDict:
+    # compress offsets
+    compressed: T.List[_CompressedSampleCompositionOffset] = []
+    for offset in sample_composition_offsets:
+        if compressed and offset == compressed[-1].sample_offset:
+            compressed[-1].sample_count += 1
+        else:
+            compressed.append(_CompressedSampleCompositionOffset(1, offset))
+
+    return {
+        "type": b"ctts",
+        "data": {
+            "entries": [dataclasses.asdict(td) for td in compressed],
+        },
+    }
+
+
 def _build_co64(raw_samples: T.Iterable[RawSample]) -> BoxDict:
     chunks = _build_chunks(raw_samples)
     return {
@@ -134,11 +159,11 @@ def _build_co64(raw_samples: T.Iterable[RawSample]) -> BoxDict:
     }
 
 
-def _build_stss(raw_samples: T.Iterable[RawSample]) -> BoxDict:
+def _build_stss(is_syncs: T.Iterable[bool]) -> BoxDict:
     return {
         "type": b"stss",
         "data": {
-            "entries": [idx + 1 for idx, s in enumerate(raw_samples) if s.is_sync],
+            "entries": [idx + 1 for idx, is_sync in enumerate(is_syncs) if is_sync],
         },
     }
 
@@ -150,6 +175,7 @@ def build_stbl_from_raw_samples(
     raw_samples = list(raw_samples)
     # It is recommended that the boxes within the Sample Table Box be in the following order:
     # Sample Description, Time to Sample, Sample to Chunk, Sample Size, Chunk Offset.
+
     boxes = [
         _build_stsd(descriptions),
         _build_stts((s.timedelta for s in raw_samples)),
@@ -159,8 +185,10 @@ def build_stbl_from_raw_samples(
         # so we can calculate the moov box size in advance
         _build_co64(raw_samples),
     ]
+    if any(s.composition_offset for s in raw_samples):
+        boxes.append(_build_ctts((s.composition_offset for s in raw_samples)))
     if any(not s.is_sync for s in raw_samples):
-        boxes.append(_build_stss(raw_samples))
+        boxes.append(_build_stss((s.is_sync for s in raw_samples)))
     return boxes
 
 
@@ -199,14 +227,17 @@ _STBLChildrenBuilderConstruct = cparser.Box32ConstructBuilder(
 
 def _update_sbtl(trak: BoxDict, sample_offset: int) -> int:
     assert trak["type"] == b"trak"
-    new_samples = []
+
+    # new samples with offsets updated
+    repositioned_samples = []
     for sample in iterate_samples([trak]):
-        new_samples.append(
+        repositioned_samples.append(
             sample_parser.RawSample(
                 description_idx=sample.description_idx,
                 offset=sample_offset,
                 size=sample.size,
                 timedelta=sample.timedelta,
+                composition_offset=sample.composition_offset,
                 is_sync=sample.is_sync,
             )
         )
@@ -215,7 +246,9 @@ def _update_sbtl(trak: BoxDict, sample_offset: int) -> int:
     descriptions, _ = sample_parser.parse_raw_samples_from_stbl(
         io.BytesIO(T.cast(bytes, stbl_box["data"]))
     )
-    stbl_children_boxes = build_stbl_from_raw_samples(descriptions, new_samples)
+    stbl_children_boxes = build_stbl_from_raw_samples(
+        descriptions, repositioned_samples
+    )
     new_stbl_bytes = _STBLChildrenBuilderConstruct.build_boxlist(stbl_children_boxes)
     stbl_box["data"] = new_stbl_bytes
 
@@ -285,7 +318,9 @@ _MOOVChildrenParserConstruct = cparser.Box64ConstructBuilder(
 
 def transform_mp4(
     src_fp: T.BinaryIO,
-    sample_generator: T.Callable[[T.BinaryIO, T.List[BoxDict]], T.Iterator[io.IOBase]],
+    sample_generator: T.Optional[
+        T.Callable[[T.BinaryIO, T.List[BoxDict]], T.Iterator[io.IOBase]]
+    ] = None,
 ) -> io_utils.ChainedIO:
     # extract ftyp
     src_fp.seek(0)
@@ -308,7 +343,10 @@ def transform_mp4(
         io_utils.SlicedIO(src_fp, sample.offset, sample.size)
         for sample in source_samples
     ]
-    sample_readers = list(sample_generator(src_fp, moov_children))
+    if sample_generator is not None:
+        sample_readers = list(sample_generator(src_fp, moov_children))
+    else:
+        sample_readers = []
 
     _update_all_trak_tkhd(moov_children)
 

--- a/mapillary_tools/sample_video.py
+++ b/mapillary_tools/sample_video.py
@@ -109,7 +109,7 @@ def wip_sample_dir(sample_dir: Path) -> Path:
     timestamp = int(time.time())
     # prefix with .mly_ffmpeg_ to avoid samples being scanned by "mapillary_tools process"
     return sample_dir.resolve().parent.joinpath(
-        f".mly_ffmpeg_{sample_dir.name}.{pid}.{timestamp}"
+        f".mly_ffmpeg_{sample_dir.name}_{pid}_{timestamp}"
     )
 
 

--- a/tests/cli/simple_mp4_parser.py
+++ b/tests/cli/simple_mp4_parser.py
@@ -40,9 +40,10 @@ def _validate_samples(
         for h, s in parser.parse_path(
             fp, [b"moov", b"trak", b"mdia", b"minf", b"stbl"]
         ):
-            descriptions, raw_samples = sample_parser.parse_raw_samples_from_stbl(
-                s, maxsize=h.maxsize
-            )
+            (
+                descriptions,
+                raw_samples,
+            ) = sample_parser.parse_raw_samples_from_stbl(s, maxsize=h.maxsize)
             samples.extend(
                 sample
                 for sample in raw_samples

--- a/tests/unit/test_simple_mp4_builder.py
+++ b/tests/unit/test_simple_mp4_builder.py
@@ -58,52 +58,107 @@ def test_build_stbl_happy():
 
     samples = [
         sample_parser.RawSample(
-            description_idx=1, offset=1, size=1, timedelta=2, is_sync=True
+            description_idx=1,
+            offset=1,
+            size=1,
+            timedelta=2,
+            composition_offset=0,
+            is_sync=True,
         ),
         sample_parser.RawSample(
-            description_idx=1, offset=2, size=9, timedelta=2, is_sync=False
+            description_idx=1,
+            offset=2,
+            size=9,
+            timedelta=2,
+            composition_offset=0,
+            is_sync=False,
         ),
     ]
     _build_and_parse_stbl(descriptions, samples)
 
     samples = [
         sample_parser.RawSample(
-            description_idx=1, offset=1, size=1, timedelta=2, is_sync=True
+            description_idx=1,
+            offset=1,
+            size=1,
+            timedelta=2,
+            composition_offset=0,
+            is_sync=True,
         ),
         sample_parser.RawSample(
-            description_idx=1, offset=2, size=2, timedelta=2, is_sync=False
+            description_idx=1,
+            offset=2,
+            size=2,
+            timedelta=2,
+            composition_offset=0,
+            is_sync=False,
         ),
         # another chunk here due to a 1-byte break
         sample_parser.RawSample(
-            description_idx=1, offset=5, size=1, timedelta=2, is_sync=True
+            description_idx=1,
+            offset=5,
+            size=1,
+            timedelta=2,
+            composition_offset=0,
+            is_sync=True,
         ),
         sample_parser.RawSample(
-            description_idx=1, offset=6, size=9, timedelta=2, is_sync=False
-        ),
-    ]
-    _build_and_parse_stbl(descriptions, samples)
-
-    samples = [
-        sample_parser.RawSample(
-            description_idx=1, offset=1, size=1, timedelta=2, is_sync=False
-        ),
-        sample_parser.RawSample(
-            description_idx=1, offset=2, size=2, timedelta=2, is_sync=True
-        ),
-        # another chunk here
-        sample_parser.RawSample(
-            description_idx=2, offset=4, size=1, timedelta=2, is_sync=True
-        ),
-        # another chunk here
-        sample_parser.RawSample(
-            description_idx=1, offset=5, size=9, timedelta=2, is_sync=True
+            description_idx=1,
+            offset=6,
+            size=9,
+            timedelta=2,
+            composition_offset=0,
+            is_sync=False,
         ),
     ]
     _build_and_parse_stbl(descriptions, samples)
 
     samples = [
         sample_parser.RawSample(
-            description_idx=1, offset=1, size=1, timedelta=2, is_sync=True
+            description_idx=1,
+            offset=1,
+            size=1,
+            timedelta=2,
+            composition_offset=0,
+            is_sync=False,
+        ),
+        sample_parser.RawSample(
+            description_idx=1,
+            offset=2,
+            size=2,
+            timedelta=2,
+            composition_offset=0,
+            is_sync=True,
+        ),
+        # another chunk here
+        sample_parser.RawSample(
+            description_idx=2,
+            offset=4,
+            size=1,
+            timedelta=2,
+            composition_offset=0,
+            is_sync=True,
+        ),
+        # another chunk here
+        sample_parser.RawSample(
+            description_idx=1,
+            offset=5,
+            size=9,
+            timedelta=2,
+            composition_offset=0,
+            is_sync=True,
+        ),
+    ]
+    _build_and_parse_stbl(descriptions, samples)
+
+    samples = [
+        sample_parser.RawSample(
+            description_idx=1,
+            offset=1,
+            size=1,
+            timedelta=2,
+            composition_offset=0,
+            is_sync=True,
         ),
     ]
     _build_and_parse_stbl(descriptions, samples)
@@ -198,16 +253,36 @@ def test_parse_raw_samples_from_stbl():
     samples = list(sample_iter)
     assert [
         sample_parser.RawSample(
-            description_idx=1, offset=1, size=1, timedelta=20, is_sync=True
+            description_idx=1,
+            offset=1,
+            size=1,
+            timedelta=20,
+            composition_offset=0,
+            is_sync=True,
         ),
         sample_parser.RawSample(
-            description_idx=1, offset=2, size=2, timedelta=30, is_sync=False
+            description_idx=1,
+            offset=2,
+            size=2,
+            timedelta=30,
+            composition_offset=0,
+            is_sync=False,
         ),
         sample_parser.RawSample(
-            description_idx=1, offset=5, size=3, timedelta=30, is_sync=True
+            description_idx=1,
+            offset=5,
+            size=3,
+            timedelta=30,
+            composition_offset=0,
+            is_sync=True,
         ),
         sample_parser.RawSample(
-            description_idx=1, offset=8, size=3, timedelta=50, is_sync=False
+            description_idx=1,
+            offset=8,
+            size=3,
+            timedelta=50,
+            composition_offset=0,
+            is_sync=False,
         ),
     ] == samples
     d = builder.build_stbl_from_raw_samples(descs, samples)


### PR DESCRIPTION
According to mp4 spec this ctts box is required if there exists bframes, without this box, the generated mp4 will be jumping back and forth as follows.

Also ctts, if present, is the table for sorting out frame presentation ordering.

sample-5s.mp4

https://user-images.githubusercontent.com/87357/204927246-f8dce529-db49-4f52-903d-e4372eec6435.mp4


- use contextmanager
- add CompositionTimeToSampleBox (ctts)
- move find_box_at_pathx to construct_mp4_parser.py
- fix: parse ctts
