### PR TITLE
fix: stop video sampling if non-exif geotag source provided

### DIFF
--- a/mapillary_tools/commands/video_process.py
+++ b/mapillary_tools/commands/video_process.py
@@ -29,20 +29,4 @@ class Command:
             )
             args[option] = {FileType.IMAGE}
 
-        if 0 <= args["video_sample_distance"]:
-            expected: GeotagSource = "exif"
-            option = "geotag_source"
-            if args[option] != expected:
-                LOG.warning(
-                    (
-                        "Since sample geotags have been written in EXIFs when you sampled videos by distance (%s meter(s)),"
-                        ' so we force the option "%s" to be "%s"'
-                        " to avoid unnecessary geotagging from the videos again"
-                    ),
-                    args["video_sample_distance"],
-                    option,
-                    expected,
-                )
-                args[option] = expected
-
         ProcessCommand().run(args)


### PR DESCRIPTION
Raise the error if non-exif geotag source is specified with the distance-based sampling

```
ERROR   - MapillaryBadParameterError: Geotagging from "gpx" works with the legacy interval-based sampling only.
To switch back, rerun the command with "--video_sample_distance -1 --video_sample_interval 2"
```


Fixes https://github.com/mapillary/mapillary_tools/issues/596