### PR TITLE
generate select filter as binary search for less stack consumption during evaluation

### DIFF
--- a/mapillary_tools/ffmpeg.py
+++ b/mapillary_tools/ffmpeg.py
@@ -195,6 +195,21 @@ class FFMPEG:
 
         self._run_ffmpeg(cmd)
 
+    def generate_binary_search(
+        self,
+        sorted_frame_indices: T.Set[int]
+    ) -> str:
+        length = len(sorted_frame_indices)
+
+        if length == 0:
+            return "0"
+
+        if length == 1:
+            return f"eq(n\\,{ sorted_frame_indices[0] })"
+
+        middle = length // 2
+        return f"if(lt(n\\,{ sorted_frame_indices[middle] })\\,{ self.generate_binary_search(sorted_frame_indices[:middle]) }\\,{ self.generate_binary_search(sorted_frame_indices[middle:]) })"
+
     def extract_specified_frames(
         self,
         video_path: Path,
@@ -226,7 +241,7 @@ class FFMPEG:
         # the maximum command line length for the CreateProcess function is 32767 characters
         # https://devblogs.microsoft.com/oldnewthing/20031210-00/?p=41553
 
-        eqs = "+".join(f"eq(n\\,{idx})" for idx in sorted(frame_indices))
+        eqs = self.generate_binary_search(sorted(frame_indices))
 
         # https://github.com/mapillary/mapillary_tools/issues/503
         if sys.platform in ["win32"]:


### PR DESCRIPTION
The current approach of calculating the sum of all equality tests requires a lot of stack space as FFmpeg's evaluator uses recursion to handle the add. Hence, FFmpeg crashed with stack overflow when selecting a larger number of images.

Some numbers for selecting N images (executed per decoded image):
- stack depth / recursion count: N + 1
- number of equality tests: N
- number of additions: N - 1
- = total instructions: 2 * N - 1

The patch implements a binary search algorithm to reduce stack consumption and also reduces the number of instruction to execute per decoded image:
- stack depth / recursion count: ld(N) + 1
- number of "less than" tests: ld(N)
- number of ifs: ld(N)
- number of equality tests: 1
- = total instructions: 2 * ld(N) + 1