### PR TITLE
Update macOS version in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11"]
-        platform: ["ubuntu-20.04", "macos-latest", "windows-latest"]
+        platform: ["ubuntu-20.04", "macos-13", "windows-latest"]
         architecture: ["x64"]
         include:
           - architecture: "x86"
@@ -53,7 +53,7 @@ jobs:
         uses: FedericoCarboni/setup-ffmpeg@v3
         # ffmpeg is not supported in the latest macOS arch:
         # Error: setup-ffmpeg can only be run on 64-bit systems
-        if: matrix.platform != 'macos-latest'
+        if: matrix.platform != 'macos-13'
 
       - name: Set up ${{ matrix.architecture }} Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build and test with Pyinstaller on MacOS
         # Enable for Python3.11 only because it often fails at codesign (subprocess timeout)
-        if: matrix.platform == 'macos-latest'
+        if: matrix.platform == 'macos-13'
         run: |
           # see https://github.com/mapillary/mapillary_tools/issues/566
           # TODO: move it to extras in setup.py


### PR DESCRIPTION
This change will enable us to make a mapillary_tools osx-x86_64 build again.