### PR TITLE
chore: remove Pillow from dev dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-Pillow; python_version>='3.8'
 pytest
 mypy
 ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ requests[socks]>=2.20.0,<3.0.0
 tqdm>=4.0,<5.0
 typing_extensions
 jsonschema~=4.17.3
-dataclasses; python_version<='3.6'


### PR DESCRIPTION

This pull request focuses on refactoring the unit tests for EXIF data handling by removing dependencies on the `Pillow` library and utilizing the `ExifRead` class for reading EXIF data. The main changes include the removal of `Pillow` from the requirements and test files, and the replacement of `Pillow`-based EXIF reading methods with methods from the `ExifRead` class.

Key changes include:

### Dependencies:
* [`requirements-dev.txt`](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcL1): Removed `Pillow` from the list of dependencies.

### Refactoring EXIF reading in tests:
* [`tests/unit/test_exifedit.py`](diffhunk://#diff-1161b74f3ede391b5edbe269d2909ef2b44efde50bda52a3e9ab167247d09c70R9-L10): Removed `Pillow` imports and related EXIF reading methods, replacing them with `ExifRead` class methods. [[1]](diffhunk://#diff-1161b74f3ede391b5edbe269d2909ef2b44efde50bda52a3e9ab167247d09c70R9-L10) [[2]](diffhunk://#diff-1161b74f3ede391b5edbe269d2909ef2b44efde50bda52a3e9ab167247d09c70L24-R25) [[3]](diffhunk://#diff-1161b74f3ede391b5edbe269d2909ef2b44efde50bda52a3e9ab167247d09c70L57-R38) [[4]](diffhunk://#diff-1161b74f3ede391b5edbe269d2909ef2b44efde50bda52a3e9ab167247d09c70L72-R51) [[5]](diffhunk://#diff-1161b74f3ede391b5edbe269d2909ef2b44efde50bda52a3e9ab167247d09c70L86-R65) [[6]](diffhunk://#diff-1161b74f3ede391b5edbe269d2909ef2b44efde50bda52a3e9ab167247d09c70L111-R80) [[7]](diffhunk://#diff-1161b74f3ede391b5edbe269d2909ef2b44efde50bda52a3e9ab167247d09c70L139-R93) [[8]](diffhunk://#diff-1161b74f3ede391b5edbe269d2909ef2b44efde50bda52a3e9ab167247d09c70L165-R114) [[9]](diffhunk://#diff-1161b74f3ede391b5edbe269d2909ef2b44efde50bda52a3e9ab167247d09c70L186-R133) [[10]](diffhunk://#diff-1161b74f3ede391b5edbe269d2909ef2b44efde50bda52a3e9ab167247d09c70L234-R176) [[11]](diffhunk://#diff-1161b74f3ede391b5edbe269d2909ef2b44efde50bda52a3e9ab167247d09c70L261-R202) [[12]](diffhunk://#diff-1161b74f3ede391b5edbe269d2909ef2b44efde50bda52a3e9ab167247d09c70L280-R217)

### Refactoring EXIF reading tests:
* [`tests/unit/test_exifread.py`](diffhunk://#diff-15fccaabadf7834477e6477cba6e73df920941fd5a56d7f2c0f3a1abfedf1f50L5): Removed `Pillow` imports and related EXIF reading methods, converting the tests to use `ExifRead` class methods and simplifying the test structure. [[1]](diffhunk://#diff-15fccaabadf7834477e6477cba6e73df920941fd5a56d7f2c0f3a1abfedf1f50L5) [[2]](diffhunk://#diff-15fccaabadf7834477e6477cba6e73df920941fd5a56d7f2c0f3a1abfedf1f50L19) [[3]](diffhunk://#diff-15fccaabadf7834477e6477cba6e73df920941fd5a56d7f2c0f3a1abfedf1f50L29-L33) [[4]](diffhunk://#diff-15fccaabadf7834477e6477cba6e73df920941fd5a56d7f2c0f3a1abfedf1f50L51-R51) [[5]](diffhunk://#diff-15fccaabadf7834477e6477cba6e73df920941fd5a56d7f2c0f3a1abfedf1f50L84-R114) [[6]](diffhunk://#diff-15fccaabadf7834477e6477cba6e73df920941fd5a56d7f2c0f3a1abfedf1f50L289-R241)