### PR TITLE
chore: increase sequence limit to 1000 images

### DIFF
--- a/mapillary_tools/constants.py
+++ b/mapillary_tools/constants.py
@@ -45,6 +45,6 @@ GOPRO_GPS_PRECISION = float(os.getenv(_ENV_PREFIX + "GOPRO_GPS_PRECISION", 15))
 # Max number of images per sequence
 MAX_SEQUENCE_LENGTH = int(os.getenv(_ENV_PREFIX + "MAX_SEQUENCE_LENGTH", 1000))
 # Max file size per sequence (sum of image filesizes in the sequence)
-MAX_SEQUENCE_FILESIZE: str = os.getenv(_ENV_PREFIX + "MAX_SEQUENCE_FILESIZE", "2G")
+MAX_SEQUENCE_FILESIZE: str = os.getenv(_ENV_PREFIX + "MAX_SEQUENCE_FILESIZE", "10G")
 # Max number of pixels per sequence (sum of image pixels in the sequence)
 MAX_SEQUENCE_PIXELS: str = os.getenv(_ENV_PREFIX + "MAX_SEQUENCE_PIXELS", "6G")

--- a/mapillary_tools/constants.py
+++ b/mapillary_tools/constants.py
@@ -43,7 +43,7 @@ GOPRO_GPS_PRECISION = float(os.getenv(_ENV_PREFIX + "GOPRO_GPS_PRECISION", 15))
 
 # WARNING: Changing the following envvars might result in failed uploads
 # Max number of images per sequence
-MAX_SEQUENCE_LENGTH = int(os.getenv(_ENV_PREFIX + "MAX_SEQUENCE_LENGTH", 500))
+MAX_SEQUENCE_LENGTH = int(os.getenv(_ENV_PREFIX + "MAX_SEQUENCE_LENGTH", 1000))
 # Max file size per sequence (sum of image filesizes in the sequence)
 MAX_SEQUENCE_FILESIZE: str = os.getenv(_ENV_PREFIX + "MAX_SEQUENCE_FILESIZE", "2G")
 # Max number of pixels per sequence (sum of image pixels in the sequence)


### PR DESCRIPTION
This pull request includes changes to the `mapillary_tools/constants.py` file, specifically modifying the environment variable defaults for sequence limits.

Changes to sequence limits:

* [`mapillary_tools/constants.py`](diffhunk://#diff-9ff8ceb711e986920337274ad817fcd4e87b7648be7e59189de5f3722bafc7feL46-R48): Increased the default `MAX_SEQUENCE_LENGTH` from 500 to 1000.
* [`mapillary_tools/constants.py`](diffhunk://#diff-9ff8ceb711e986920337274ad817fcd4e87b7648be7e59189de5f3722bafc7feL46-R48): Increased the default `MAX_SEQUENCE_FILESIZE` from 2G to 10G.