### PR TITLE
remove SSL hooks in pyinstaller

### DIFF
--- a/pyinstaller/hooks/hook-urllib2.py
+++ b/pyinstaller/hooks/hook-urllib2.py
@@ -1,5 +1,0 @@
-from PyInstaller.compat import is_darwin
-
-if (is_darwin):
-    import certifi
-    datas = [(certifi.where(), 'lib')]

--- a/pyinstaller/runtime-hooks/ssl.py
+++ b/pyinstaller/runtime-hooks/ssl.py
@@ -1,5 +1,0 @@
-import os
-import sys
-
-if sys.platform == 'darwin':
-    os.environ['SSL_CERT_FILE'] = os.path.join(sys._MEIPASS, 'lib', 'cacert.pem')


### PR DESCRIPTION
pyinstaller does include all certifi cacerts in the bundle, so there is no need to do it again