### PR TITLE
feat: sync GPX with first GPS timestamp when available

### DIFF
--- a/mapillary_tools/camm/camm_parser.py
+++ b/mapillary_tools/camm/camm_parser.py
@@ -146,10 +146,7 @@ def _filter_telemetry_by_elst_segments(
 
     if not elst:
         for m in measurements:
-            if dataclasses.is_dataclass(m):
-                yield dataclasses.replace(m, time=m.time + offset)
-            else:
-                m._replace(time=m.time + offset)
+            yield dataclasses.replace(m, time=m.time + offset)
         return
 
     elst.sort(key=lambda entry: entry[0])
@@ -161,10 +158,7 @@ def _filter_telemetry_by_elst_segments(
         if m.time < media_time:
             pass
         elif m.time <= media_time + duration:
-            if dataclasses.is_dataclass(m):
-                yield dataclasses.replace(m, time=m.time + offset)
-            else:
-                m._replace(time=m.time + offset)
+            yield dataclasses.replace(m, time=m.time + offset)
         else:
             elst_idx += 1
 

--- a/mapillary_tools/geotag/geotag_videos_from_exiftool_video.py
+++ b/mapillary_tools/geotag/geotag_videos_from_exiftool_video.py
@@ -4,11 +4,9 @@ import xml.etree.ElementTree as ET
 from multiprocessing import Pool
 from pathlib import Path
 
-from mapillary_tools import utils
-
 from tqdm import tqdm
 
-from .. import exceptions, exiftool_read, geo, types
+from .. import exceptions, exiftool_read, geo, types, utils
 from ..exiftool_read_video import ExifToolReadVideo
 from ..telemetry import GPSPoint
 from . import gpmf_gps_filter, utils as video_utils

--- a/mapillary_tools/geotag/geotag_videos_from_video.py
+++ b/mapillary_tools/geotag/geotag_videos_from_video.py
@@ -4,11 +4,9 @@ import typing as T
 from multiprocessing import Pool
 from pathlib import Path
 
-from mapillary_tools import utils
-
 from tqdm import tqdm
 
-from .. import exceptions, geo, types
+from .. import exceptions, geo, types, utils
 from ..camm import camm_parser
 from ..mp4 import simple_mp4_parser as sparser
 from ..telemetry import GPSPoint

--- a/mapillary_tools/video_data_extraction/extract_video_data.py
+++ b/mapillary_tools/video_data_extraction/extract_video_data.py
@@ -122,12 +122,7 @@ class VideoDataExtractor:
                 {**log_vars, "points": len(points)},
             )
 
-        points = self._sanitize_points(points)
-
-        if parser.must_rebase_times_to_zero:
-            points = self._rebase_times(points)
-
-        return points
+        return self._sanitize_points(points)
 
     @staticmethod
     def _check_paths(import_paths: T.Sequence[Path]):
@@ -178,15 +173,4 @@ class VideoDataExtractor:
         if stationary:
             raise exceptions.MapillaryStationaryVideoError("Stationary video")
 
-        return points
-
-    @staticmethod
-    def _rebase_times(points: T.Sequence[geo.Point]):
-        """
-        Make point times start from 0
-        """
-        if points:
-            first_timestamp = points[0].time
-            for p in points:
-                p.time = p.time - first_timestamp
         return points

--- a/mapillary_tools/video_data_extraction/extractors/base_parser.py
+++ b/mapillary_tools/video_data_extraction/extractors/base_parser.py
@@ -33,11 +33,6 @@ class BaseParser(metaclass=abc.ABCMeta):
     def parser_label(self) -> str:
         raise NotImplementedError
 
-    @property
-    @abc.abstractmethod
-    def must_rebase_times_to_zero(self) -> bool:
-        raise NotImplementedError
-
     @abc.abstractmethod
     def extract_points(self) -> T.Sequence[geo.Point]:
         raise NotImplementedError
@@ -67,3 +62,14 @@ class BaseParser(metaclass=abc.ABCMeta):
         ).resolve()
 
         return abs_path if abs_path.is_file() else None
+
+    @staticmethod
+    def _rebase_times(points: T.Sequence[geo.Point], offset: float = 0.0):
+        """
+        Make point times start from 0
+        """
+        if points:
+            first_timestamp = points[0].time
+            for p in points:
+                p.time = (p.time - first_timestamp) + offset
+        return points

--- a/mapillary_tools/video_data_extraction/extractors/exiftool_xml_parser.py
+++ b/mapillary_tools/video_data_extraction/extractors/exiftool_xml_parser.py
@@ -13,7 +13,6 @@ from .base_parser import BaseParser
 
 class ExiftoolXmlParser(BaseParser):
     default_source_pattern = "%g.xml"
-    must_rebase_times_to_zero = True
     parser_label = "exiftool_xml"
 
     exifToolReadVideo: T.Optional[ExifToolReadVideo] = None
@@ -39,9 +38,11 @@ class ExiftoolXmlParser(BaseParser):
         self.exifToolReadVideo = ExifToolReadVideo(ET.ElementTree(element))
 
     def extract_points(self) -> T.Sequence[geo.Point]:
-        return (
+        gps_points = (
             self.exifToolReadVideo.extract_gps_track() if self.exifToolReadVideo else []
         )
+        self._rebase_times(gps_points)
+        return gps_points
 
     def extract_make(self) -> T.Optional[str]:
         return self.exifToolReadVideo.extract_make() if self.exifToolReadVideo else None

--- a/mapillary_tools/video_data_extraction/extractors/gpx_parser.py
+++ b/mapillary_tools/video_data_extraction/extractors/gpx_parser.py
@@ -1,27 +1,49 @@
 import typing as T
+import logging
 
-from ... import geo
+from ... import geo, telemetry
 from ...geotag import geotag_images_from_gpx_file
 from .base_parser import BaseParser
 from .generic_video_parser import GenericVideoParser
 
 
+LOG = logging.getLogger(__name__)
+
+
 class GpxParser(BaseParser):
     default_source_pattern = "%g.gpx"
-    must_rebase_times_to_zero = True
     parser_label = "gpx"
 
     def extract_points(self) -> T.Sequence[geo.Point]:
         path = self.geotag_source_path
         if not path:
             return []
-        try:
-            tracks = geotag_images_from_gpx_file.parse_gpx(path)
-        except Exception:
-            return []
 
-        points: T.Sequence[geo.Point] = sum(tracks, [])
-        return points
+        gpx_tracks = geotag_images_from_gpx_file.parse_gpx(path)
+        if 1 < len(gpx_tracks):
+            LOG.warning(
+                "Found %s tracks in the GPX file %s. Will merge points in all the tracks as a single track for interpolation",
+                len(gpx_tracks),
+                self.videoPath,
+            )
+
+        gpx_points: T.Sequence[geo.Point] = sum(gpx_tracks, [])
+        if not gpx_points:
+            return gpx_points
+
+        # Extract first GPS timestamp (if found) for synchronization
+        offset: float = 0.0
+        parser = GenericVideoParser(self.videoPath, self.options, self.parserOptions)
+        gps_points = parser.extract_points()
+        if gps_points:
+            first_gps_point = gps_points[0]
+            if isinstance(first_gps_point, telemetry.GPSPoint):
+                if first_gps_point.epoch_time is not None:
+                    offset = gpx_points[0].time - first_gps_point.epoch_time
+
+        self._rebase_times(gpx_points, offset=offset)
+
+        return gpx_points
 
     def extract_make(self) -> T.Optional[str]:
         parser = GenericVideoParser(self.videoPath, self.options, self.parserOptions)

--- a/mapillary_tools/video_data_extraction/extractors/gpx_parser.py
+++ b/mapillary_tools/video_data_extraction/extractors/gpx_parser.py
@@ -1,5 +1,6 @@
-import typing as T
+import datetime
 import logging
+import typing as T
 
 from ... import geo, telemetry
 from ...geotag import geotag_images_from_gpx_file
@@ -39,7 +40,19 @@ class GpxParser(BaseParser):
             first_gps_point = gps_points[0]
             if isinstance(first_gps_point, telemetry.GPSPoint):
                 if first_gps_point.epoch_time is not None:
+                    first_gpx_dt = datetime.datetime.fromtimestamp(
+                        gpx_points[0].time, tz=datetime.timezone.utc
+                    )
+                    first_gps_dt = datetime.datetime.fromtimestamp(
+                        first_gps_point.epoch_time, tz=datetime.timezone.utc
+                    )
                     offset = gpx_points[0].time - first_gps_point.epoch_time
+                    LOG.warning(
+                        "Found offset between GPX %s and video GPS timestamps %s: %s",
+                        first_gpx_dt,
+                        first_gps_dt,
+                        offset,
+                    )
 
         self._rebase_times(gpx_points, offset=offset)
 


### PR DESCRIPTION
When we found GPS timestamps videos (e.g. GoPro or CAMM), we will use the first GPS timestamp to synchronize GPX tracks. NOTE we have to assume the timestamps in GPX are also using the GPS clock.