### PR TITLE
improve GPX parsing error message

### DIFF
--- a/mapillary_tools/geotag/geotag_images_from_gpx_file.py
+++ b/mapillary_tools/geotag/geotag_images_from_gpx_file.py
@@ -25,7 +25,13 @@ class GeotagImagesFromGPXFile(GeotagImagesFromGeneric):
         num_processes: T.Optional[int] = None,
     ):
         super().__init__()
-        tracks = parse_gpx(source_path)
+        try:
+            tracks = parse_gpx(source_path)
+        except Exception as ex:
+            raise RuntimeError(
+                f"Error parsing GPX {source_path}: {ex.__class__.__name__}: {ex}"
+            )
+
         if 1 < len(tracks):
             LOG.warning(
                 "Found %s tracks in the GPX file %s. Will merge points in all the tracks as a single track for interpolation",

--- a/mapillary_tools/video_data_extraction/extractors/gpx_parser.py
+++ b/mapillary_tools/video_data_extraction/extractors/gpx_parser.py
@@ -20,7 +20,13 @@ class GpxParser(BaseParser):
         if not path:
             return []
 
-        gpx_tracks = geotag_images_from_gpx_file.parse_gpx(path)
+        try:
+            gpx_tracks = geotag_images_from_gpx_file.parse_gpx(path)
+        except Exception as ex:
+            raise RuntimeError(
+                f"Error parsing GPX {path}: {ex.__class__.__name__}: {ex}"
+            )
+
         if 1 < len(gpx_tracks):
             LOG.warning(
                 "Found %s tracks in the GPX file %s. Will merge points in all the tracks as a single track for interpolation",


### PR DESCRIPTION
A more explicit error when GPX parsing fails:
```
[
  {
    "error": {
      "type": "RuntimeError",
      "message": "Error parsing GPX /usr/xx/Downloads/Forward.gpx: UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb0 in position 37: invalid start byte"
    },
    "filename": "/usr/xx/Downloads/Forward.mp4",
    "filetype": "video"
  }
]