### PR TITLE
fix: enforce camera info to be extracted from video itself instead of gpx

### DIFF
--- a/mapillary_tools/video_data_extraction/extractors/camm_parser.py
+++ b/mapillary_tools/video_data_extraction/extractors/camm_parser.py
@@ -13,8 +13,12 @@ class CammParser(BaseParser):
     parser_label = "camm"
 
     @functools.cached_property
-    def __camera_info(self) -> T.Tuple[str, str]:
-        with self.videoPath.open("rb") as fp:
+    def _camera_info(self) -> T.Tuple[str, str]:
+        source_path = self.geotag_source_path
+        if not source_path:
+            return "", ""
+
+        with source_path.open("rb") as fp:
             return camm_parser.extract_camera_make_and_model(fp)
 
     def extract_points(self) -> T.Sequence[geo.Point]:
@@ -28,15 +32,7 @@ class CammParser(BaseParser):
                 return []
 
     def extract_make(self) -> T.Optional[str]:
-        source_path = self.geotag_source_path
-        if not source_path:
-            return None
-        with source_path.open("rb") as _fp:
-            return self.__camera_info[0] or None
+        return self._camera_info[0] or None
 
     def extract_model(self) -> T.Optional[str]:
-        source_path = self.geotag_source_path
-        if not source_path:
-            return None
-        with source_path.open("rb") as _fp:
-            return self.__camera_info[1] or None
+        return self._camera_info[1] or None

--- a/mapillary_tools/video_data_extraction/extractors/gpx_parser.py
+++ b/mapillary_tools/video_data_extraction/extractors/gpx_parser.py
@@ -69,9 +69,11 @@ class GpxParser(BaseParser):
         return gpx_points
 
     def extract_make(self) -> T.Optional[str]:
-        parser = GenericVideoParser(self.videoPath, self.options, self.parserOptions)
+        # Use an empty dictionary to force video parsers to extract make/model from the video metadata itself
+        parser = GenericVideoParser(self.videoPath, self.options, {})
         return parser.extract_make()
 
     def extract_model(self) -> T.Optional[str]:
-        parser = GenericVideoParser(self.videoPath, self.options, self.parserOptions)
+        # Use an empty dictionary to force video parsers to extract make/model from the video metadata itself
+        parser = GenericVideoParser(self.videoPath, self.options, {})
         return parser.extract_model()


### PR DESCRIPTION
Problem is when run:
```
mapillary_tools process --video_geotag_source '{"source":"gpx","pattern":"/external_gpx/%g.gpx"}' ~/Downloads/video\ full.360
```

will throw this exception (warning) and skip gpx geotagging:

```
Exception for parser gpx while processing source /external_gpx/video full.gpx: "unable find box at path [b'moov']"
```