### PR TITLE
improve: use chunked transfer encoding to stream large files

### DIFF
--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -195,7 +195,6 @@ class Uploader:
                 upload_api_v4.FakeUploadService(
                     user_access_token=self.user_items["user_upload_token"],
                     session_key=session_key,
-                    entity_size=entity_size,
                     organization_id=self.user_items.get("MAPOrganizationKey"),
                     cluster_filetype=cluster_filetype,
                     chunk_size=self.chunk_size,
@@ -205,7 +204,6 @@ class Uploader:
             upload_service = upload_api_v4.UploadService(
                 user_access_token=self.user_items["user_upload_token"],
                 session_key=session_key,
-                entity_size=entity_size,
                 organization_id=self.user_items.get("MAPOrganizationKey"),
                 cluster_filetype=cluster_filetype,
                 chunk_size=self.chunk_size,

--- a/tests/unit/test_upload_api_v4.py
+++ b/tests/unit/test_upload_api_v4.py
@@ -1,0 +1,47 @@
+import io
+import py
+
+from mapillary_tools import upload_api_v4
+
+from ..integration.fixtures import setup_upload
+
+
+def test_upload(setup_upload: py.path.local):
+    upload_service = upload_api_v4.FakeUploadService(
+        user_access_token="TEST",
+        session_key="FOOBAR.txt",
+        chunk_size=1,
+    )
+    upload_service._error_ratio = 0
+    content = b"double_foobar"
+    cluster_id = upload_service.upload(io.BytesIO(content))
+    assert isinstance(cluster_id, str), cluster_id
+    assert (setup_upload.join("FOOBAR.txt").read_binary()) == content
+
+    # reupload should not affect the file
+    upload_service.upload(io.BytesIO(content))
+    assert (setup_upload.join("FOOBAR.txt").read_binary()) == content
+
+
+def test_upload_chunks(setup_upload: py.path.local):
+    upload_service = upload_api_v4.FakeUploadService(
+        user_access_token="TEST",
+        session_key="FOOBAR2.txt",
+        chunk_size=1,
+    )
+    upload_service._error_ratio = 0
+
+    def _gen_chunks():
+        yield b"foo"
+        yield b""
+        yield b"bar"
+        yield b""
+
+    cluster_id = upload_service.upload_chunks(_gen_chunks())
+
+    assert isinstance(cluster_id, str), cluster_id
+    assert (setup_upload.join("FOOBAR2.txt").read_binary()) == b"foobar"
+
+    # reupload should not affect the file
+    upload_service.upload_chunks(_gen_chunks())
+    assert (setup_upload.join("FOOBAR2.txt").read_binary()) == b"foobar"


### PR DESCRIPTION
## Before

When upload a large file, we slice the large binary stream into chunks (16MB per chunk by default -- can be specified by `MAPILLARY_TOOLS_UPLOAD_CHUNK_SIZE_MB`), and then upload each chunk to the server per HTTP request. It means to upload a 16GB file, it will send over 1000 HTTP requests.

I suspect that many potential issues are caused by initializing HTTP requests instead of the actual data transferring after the initialization, especially in an unreliable and dynamic network environment. To address these issues, we are switching to [Chunked transfer encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding) that the upload server supports.

## After

To upload a 16GB file, we still slice it into chunks by 16MB, but within **a single HTTP request**. This is what [Chunked transfer encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding) supports, and can be easily done by passing a chunk generator to `requests.post(data=chunk_generator)`.

