### PR TITLE
improve: speed up native EXIF parsing

### DIFF
--- a/mapillary_tools/exif_read.py
+++ b/mapillary_tools/exif_read.py
@@ -520,14 +520,15 @@ class ExifReadFromEXIF(ExifReadABC):
         if isinstance(path_or_stream, Path):
             with path_or_stream.open("rb") as fp:
                 try:
-                    self.tags = exifread.process_file(fp, details=True, debug=True)
+                    # Turn off details and debug for performance reasons
+                    self.tags = exifread.process_file(fp, details=False, debug=False)
                 except Exception:
                     self.tags = {}
 
         else:
             try:
                 self.tags = exifread.process_file(
-                    path_or_stream, details=True, debug=True
+                    path_or_stream, details=False, debug=False
                 )
             except Exception:
                 self.tags = {}

--- a/mapillary_tools/exif_read.py
+++ b/mapillary_tools/exif_read.py
@@ -961,3 +961,27 @@ class ExifRead(ExifReadFromEXIF):
         if val is not None:
             return val
         return None
+
+    def extract_width(self) -> T.Optional[int]:
+        val = super().extract_width()
+        if val is not None:
+            return val
+        xmp = self._xmp_with_reason("width")
+        if xmp is None:
+            return None
+        val = xmp.extract_width()
+        if val is not None:
+            return val
+        return None
+
+    def extract_height(self) -> T.Optional[int]:
+        val = super().extract_height()
+        if val is not None:
+            return val
+        xmp = self._xmp_with_reason("width")
+        if xmp is None:
+            return None
+        val = xmp.extract_height()
+        if val is not None:
+            return val
+        return None

--- a/mapillary_tools/geotag/geotag_images_from_exif.py
+++ b/mapillary_tools/geotag/geotag_images_from_exif.py
@@ -64,9 +64,9 @@ class GeotagImagesFromEXIF(GeotagImagesFromGeneric):
         try:
             with image_path.open("rb") as fp:
                 exif = ExifRead(fp)
-            image_metadata = GeotagImagesFromEXIF.build_image_metadata(
-                image_path, exif, skip_lonlat_error=skip_lonlat_error
-            )
+                image_metadata = GeotagImagesFromEXIF.build_image_metadata(
+                    image_path, exif, skip_lonlat_error=skip_lonlat_error
+                )
         except Exception as ex:
             return types.describe_error_metadata(
                 ex, image_path, filetype=types.FileType.IMAGE

--- a/mapillary_tools/geotag/geotag_images_from_exiftool.py
+++ b/mapillary_tools/geotag/geotag_images_from_exiftool.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 
 from .. import exceptions, exiftool_read, types
 from .geotag_from_generic import GeotagImagesFromGeneric
-from .geotag_images_from_exif import GeotagImagesFromEXIF, verify_image_exif_write
+from .geotag_images_from_exif import GeotagImagesFromEXIF
 
 LOG = logging.getLogger(__name__)
 
@@ -40,10 +40,6 @@ class GeotagImagesFromExifTool(GeotagImagesFromGeneric):
             with image_path.open("rb") as fp:
                 image_bytesio = io.BytesIO(fp.read())
             image_bytesio.seek(0, io.SEEK_SET)
-            verify_image_exif_write(
-                image_metadata,
-                image_bytes=image_bytesio.read(),
-            )
         except Exception as ex:
             return types.describe_error_metadata(
                 ex, image_path, filetype=types.FileType.IMAGE

--- a/mapillary_tools/process_geotag_properties.py
+++ b/mapillary_tools/process_geotag_properties.py
@@ -1,8 +1,10 @@
 import collections
 import datetime
+import itertools
 import json
 import logging
 import typing as T
+from multiprocessing import Pool
 from pathlib import Path
 
 from tqdm import tqdm
@@ -444,6 +446,57 @@ def _show_stats_per_filetype(
             )
 
 
+_IT = T.TypeVar("_IT")
+
+
+def split_if(
+    it: T.Iterable[_IT], sep: T.Callable[[_IT], bool]
+) -> T.Tuple[T.List[_IT], T.List[_IT]]:
+    yes, no = [], []
+    for e in it:
+        if sep(e):
+            yes.append(e)
+        else:
+            no.append(e)
+    return yes, no
+
+
+def _validate_metadatas(
+    metadatas: T.Sequence[types.MetadataOrError], num_processes: T.Optional[int]
+) -> T.List[types.MetadataOrError]:
+    # validating metadatas is slow, hence multiprocessing
+    if num_processes is None:
+        pool_num_processes = None
+        disable_multiprocessing = False
+    else:
+        pool_num_processes = max(num_processes, 1)
+        disable_multiprocessing = num_processes <= 0
+    with Pool(processes=pool_num_processes) as pool:
+        validated_metadatas_iter: T.Iterator[types.MetadataOrError]
+        if disable_multiprocessing:
+            validated_metadatas_iter = map(types.validate_and_fail_metadata, metadatas)
+        else:
+            # Do not pass error metadatas where the error object can not be pickled for multiprocessing to work
+            # Otherwise we get:
+            # TypeError: __init__() missing 3 required positional arguments: 'image_time', 'gpx_start_time', and 'gpx_end_time'
+            # See https://stackoverflow.com/a/61432070
+            yes, no = split_if(metadatas, lambda m: isinstance(m, types.ErrorMetadata))
+            no_iter = pool.imap(
+                types.validate_and_fail_metadata,
+                no,
+            )
+            validated_metadatas_iter = itertools.chain(yes, no_iter)
+        return list(
+            tqdm(
+                validated_metadatas_iter,
+                desc="Validating metadatas",
+                unit="metadata",
+                disable=LOG.getEffectiveLevel() <= logging.DEBUG,
+                total=len(metadatas),
+            )
+        )
+
+
 def process_finalize(
     import_path: T.Union[T.Sequence[Path], Path],
     metadatas: T.List[types.MetadataOrError],
@@ -458,6 +511,7 @@ def process_finalize(
     offset_time: float = 0.0,
     offset_angle: float = 0.0,
     desc_path: T.Optional[str] = None,
+    num_processes: T.Optional[int] = None,
 ) -> T.List[types.MetadataOrError]:
     for metadata in metadatas:
         if isinstance(metadata, types.VideoMetadata):
@@ -481,6 +535,9 @@ def process_finalize(
         offset_time=offset_time,
         offset_angle=offset_angle,
     )
+
+    LOG.debug("Validating %d metadatas", len(metadatas))
+    metadatas = _validate_metadatas(metadatas, num_processes=num_processes)
 
     _overwrite_exif_tags(
         # search image metadatas again because some of them might have been failed

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -224,7 +224,9 @@ def verify_descs(expected: T.List[T.Dict], actual: T.Union[Path, T.List[T.Dict]]
         actual_desc = actual_map.get(filename)
         assert actual_desc is not None, expected_desc
         if "error" in expected_desc:
-            assert expected_desc["error"]["type"] == actual_desc["error"]["type"]
+            assert expected_desc["error"]["type"] == actual_desc.get("error", {}).get(
+                "type"
+            ), f"{expected_desc=} != {actual_desc=}"
             if "message" in expected_desc["error"]:
                 assert (
                     expected_desc["error"]["message"] == actual_desc["error"]["message"]

--- a/tests/integration/test_history.py
+++ b/tests/integration/test_history.py
@@ -1,5 +1,4 @@
 import subprocess
-from pathlib import Path
 
 import py.path
 import pytest
@@ -10,7 +9,6 @@ from .fixtures import (
     setup_data,
     setup_upload,
     USERNAME,
-    verify_descs,
 )
 
 UPLOAD_FLAGS = f"--dry_run --user_name={USERNAME}"

--- a/tests/integration/test_history.py
+++ b/tests/integration/test_history.py
@@ -33,38 +33,6 @@ def test_upload_images(
         upload.remove()
 
     x = subprocess.run(
-        f"{EXECUTABLE} process --file_types=image {str(setup_data)}",
-        shell=True,
-    )
-    assert x.returncode == 0, x.stderr
-    verify_descs(
-        [
-            {
-                "error": {
-                    "message": "The image was already uploaded",
-                    "type": "MapillaryUploadedAlreadyError",
-                },
-                "filename": str(Path(setup_data.join("images").join("DSC00001.JPG"))),
-            },
-            {
-                "error": {
-                    "message": "The image was already uploaded",
-                    "type": "MapillaryUploadedAlreadyError",
-                },
-                "filename": str(Path(setup_data.join("images").join("DSC00497.JPG"))),
-            },
-            {
-                "error": {
-                    "message": "The image was already uploaded",
-                    "type": "MapillaryUploadedAlreadyError",
-                },
-                "filename": str(Path(setup_data.join("images").join("V0370574.JPG"))),
-            },
-        ],
-        Path(setup_data, "mapillary_image_description.json"),
-    )
-
-    x = subprocess.run(
         f"{EXECUTABLE} process_and_upload --file_types=image {UPLOAD_FLAGS} {str(setup_data)}",
         shell=True,
     )

--- a/tests/unit/test_sequence_processing.py
+++ b/tests/unit/test_sequence_processing.py
@@ -456,7 +456,7 @@ def test_process_finalize(setup_data):
             "MAPLongitude": 1,
             "MAPCaptureTime": "1970_01_01_00_00_02_000",
             "MAPCompassHeading": {"TrueHeading": 17.0, "MagneticHeading": 17.0},
-            "md5sum": "346c064df2c194e20ea98708fd61ac10",
+            "md5sum": None,
         },
         {
             "error": {


### PR DESCRIPTION
- **disable metadata validation and upload status in process stage**
- **turn off detials and debug flags in exifread.process_file**
- **improve exif extraction**

Before: processing 9852 images
```
uv run -m mapillary_tools.commands process  --desc_path /tmp/foo.json   66.19s user 8.62s system 515% cpu 14.508 total
```

After: processing 9852 images (without validation)
```
uv run -m mapillary_tools.commands process  --desc_path /tmp/foo.json   5.98s user 2.37s system 238% cpu 3.494 total
```

After: processing 9852 images (with validation)
```
uv run -m mapillary_tools.commands process  --desc_path /tmp/foo.json   14.24s user 3.97s system 277% cpu 6.570 total
```
