### PR TITLE
refactor: improve uploader related modules

### DIFF
--- a/mapillary_tools/api_v4.py
+++ b/mapillary_tools/api_v4.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 import logging
 import os
@@ -100,9 +102,9 @@ def _sanitize(headers: T.Mapping[T.Any, T.Any]) -> T.Mapping[T.Any, T.Any]:
 def _log_debug_request(
     method: str,
     url: str,
-    json: T.Optional[T.Dict] = None,
-    params: T.Optional[T.Dict] = None,
-    headers: T.Optional[T.Dict] = None,
+    json: dict | None = None,
+    params: dict | None = None,
+    headers: dict | None = None,
     timeout: T.Any = None,
 ):
     if logging.getLogger().getEffectiveLevel() <= logging.DEBUG:
@@ -157,8 +159,8 @@ def readable_http_error(ex: requests.HTTPError) -> str:
 
 def request_post(
     url: str,
-    data: T.Optional[T.Any] = None,
-    json: T.Optional[dict] = None,
+    data: T.Any | None = None,
+    json: dict | None = None,
     **kwargs,
 ) -> requests.Response:
     global USE_SYSTEM_CERTS
@@ -197,7 +199,7 @@ def request_post(
 
 def request_get(
     url: str,
-    params: T.Optional[dict] = None,
+    params: dict | None = None,
     **kwargs,
 ) -> requests.Response:
     global USE_SYSTEM_CERTS
@@ -300,7 +302,7 @@ def fetch_organization(
 
 def fetch_user_or_me(
     user_access_token: str,
-    user_id: T.Optional[T.Union[int, str]] = None,
+    user_id: int | str | None = None,
 ) -> requests.Response:
     if user_id is None:
         url = f"{MAPILLARY_GRAPH_API_ENDPOINT}/me"

--- a/mapillary_tools/api_v4.py
+++ b/mapillary_tools/api_v4.py
@@ -1,8 +1,8 @@
+import enum
 import logging
 import os
 import ssl
 import typing as T
-import enum
 from json import dumps
 
 import requests

--- a/mapillary_tools/authenticate.py
+++ b/mapillary_tools/authenticate.py
@@ -7,8 +7,9 @@ import re
 import sys
 import typing as T
 
-import requests
 import jsonschema
+
+import requests
 
 from . import api_v4, config, constants, exceptions, types
 

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -512,12 +512,18 @@ def _upload_everything(
                 "sequence_idx": idx,
                 "file_type": video_metadata.filetype.value,
                 "import_path": str(video_metadata.filename),
+                "md5sum": video_metadata.md5sum,
             }
+
+            session_key = uploader._session_key(
+                video_metadata.md5sum, upload_api_v4.ClusterFileType.CAMM
+            )
+
             try:
                 cluster_id = mly_uploader.upload_stream(
                     T.cast(T.BinaryIO, camm_fp),
                     upload_api_v4.ClusterFileType.CAMM,
-                    video_metadata.md5sum,
+                    session_key,
                     progress=T.cast(T.Dict[str, T.Any], progress),
                 )
             except Exception as ex:

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -507,7 +507,7 @@ def _upload_everything(
 
         with video_metadata.filename.open("rb") as src_fp:
             camm_fp = simple_mp4_builder.transform_mp4(src_fp, generator)
-            progress: uploader.FileProgress = {
+            progress: uploader.SequenceProgress = {
                 "total_sequence_count": len(specified_video_metadatas),
                 "sequence_idx": idx,
                 "file_type": video_metadata.filetype.value,
@@ -634,7 +634,7 @@ def _upload_zipfiles(
     zip_paths: T.Sequence[Path],
 ) -> None:
     for idx, zip_path in enumerate(zip_paths):
-        progress: uploader.FileProgress = {
+        progress: uploader.SequenceProgress = {
             "total_sequence_count": len(zip_paths),
             "sequence_idx": idx,
             "import_path": str(zip_path),

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -29,7 +29,7 @@ from .gpmf import gpmf_parser
 from .mp4 import simple_mp4_builder
 from .types import FileType
 
-JSONDict = dict[str, T.Union[str, int, float, None]]
+JSONDict = T.Dict[str, T.Union[str, int, float, None]]
 
 LOG = logging.getLogger(__name__)
 MAPILLARY_DISABLE_API_LOGGING = os.getenv("MAPILLARY_DISABLE_API_LOGGING")

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -516,7 +516,7 @@ def _upload_everything(
                     T.cast(T.BinaryIO, camm_fp),
                     upload_api_v4.ClusterFileType.CAMM,
                     video_metadata.md5sum,
-                    event_payload=event_payload,
+                    progress=event_payload,
                 )
             except Exception as ex:
                 raise UploadError(ex) from ex

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -505,7 +505,7 @@ def _upload_everything(
 
         with video_metadata.filename.open("rb") as src_fp:
             camm_fp = simple_mp4_builder.transform_mp4(src_fp, generator)
-            event_payload: uploader.Progress = {
+            progress: uploader.FileProgress = {
                 "total_sequence_count": len(specified_video_metadatas),
                 "sequence_idx": idx,
                 "file_type": video_metadata.filetype.value,
@@ -516,7 +516,7 @@ def _upload_everything(
                     T.cast(T.BinaryIO, camm_fp),
                     upload_api_v4.ClusterFileType.CAMM,
                     video_metadata.md5sum,
-                    progress=event_payload,
+                    progress=T.cast(dict[str, T.Any], progress),
                 )
             except Exception as ex:
                 raise UploadError(ex) from ex
@@ -632,14 +632,14 @@ def _upload_zipfiles(
     zip_paths: T.Sequence[Path],
 ) -> None:
     for idx, zip_path in enumerate(zip_paths):
-        event_payload: uploader.Progress = {
+        progress: uploader.FileProgress = {
             "total_sequence_count": len(zip_paths),
             "sequence_idx": idx,
             "import_path": str(zip_path),
         }
         try:
             cluster_id = uploader.ZipImageSequence.prepare_zipfile_and_upload(
-                zip_path, mly_uploader, event_payload=event_payload
+                zip_path, mly_uploader, progress=progress
             )
         except Exception as ex:
             raise UploadError(ex) from ex

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -463,9 +463,9 @@ def _upload_everything(
     )
     if specified_image_metadatas:
         try:
-            clusters = mly_uploader.upload_images(
+            clusters = uploader.ZipImageSequence.prepare_images_and_upload(
                 specified_image_metadatas,
-                event_payload={"file_type": FileType.IMAGE.value},
+                mly_uploader,
             )
         except Exception as ex:
             raise UploadError(ex) from ex
@@ -635,12 +635,11 @@ def _upload_zipfiles(
         event_payload: uploader.Progress = {
             "total_sequence_count": len(zip_paths),
             "sequence_idx": idx,
-            "file_type": FileType.ZIP.value,
             "import_path": str(zip_path),
         }
         try:
-            cluster_id = mly_uploader.upload_zipfile(
-                zip_path, event_payload=event_payload
+            cluster_id = uploader.ZipImageSequence.prepare_zipfile_and_upload(
+                zip_path, mly_uploader, event_payload=event_payload
             )
         except Exception as ex:
             raise UploadError(ex) from ex

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -29,7 +29,7 @@ from .gpmf import gpmf_parser
 from .mp4 import simple_mp4_builder
 from .types import FileType
 
-JSONDict = dict[str, str | int | float | None]
+JSONDict = dict[str, T.Union[str, int, float, None]]
 
 LOG = logging.getLogger(__name__)
 MAPILLARY_DISABLE_API_LOGGING = os.getenv("MAPILLARY_DISABLE_API_LOGGING")

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -518,7 +518,7 @@ def _upload_everything(
                     T.cast(T.BinaryIO, camm_fp),
                     upload_api_v4.ClusterFileType.CAMM,
                     video_metadata.md5sum,
-                    progress=T.cast(dict[str, T.Any], progress),
+                    progress=T.cast(T.Dict[str, T.Any], progress),
                 )
             except Exception as ex:
                 raise UploadError(ex) from ex

--- a/mapillary_tools/upload_api_v4.py
+++ b/mapillary_tools/upload_api_v4.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 import io
 import os
@@ -36,12 +38,12 @@ class ClusterFileType(enum.Enum):
 class UploadService:
     user_access_token: str
     session_key: str
-    callbacks: T.List[T.Callable[[bytes, T.Optional[requests.Response]], None]]
+    callbacks: list[T.Callable[[bytes, requests.Response | None], None]]
     cluster_filetype: ClusterFileType
-    organization_id: T.Optional[T.Union[str, int]]
+    organization_id: str | int | None
     chunk_size: int
 
-    MIME_BY_CLUSTER_TYPE: T.Dict[ClusterFileType, str] = {
+    MIME_BY_CLUSTER_TYPE: dict[ClusterFileType, str] = {
         ClusterFileType.ZIP: "application/zip",
         ClusterFileType.BLACKVUE: "video/mp4",
         ClusterFileType.CAMM: "video/mp4",
@@ -51,7 +53,7 @@ class UploadService:
         self,
         user_access_token: str,
         session_key: str,
-        organization_id: T.Optional[T.Union[str, int]] = None,
+        organization_id: str | int | None = None,
         cluster_filetype: ClusterFileType = ClusterFileType.ZIP,
         chunk_size: int = DEFAULT_CHUNK_SIZE,
     ):
@@ -83,7 +85,7 @@ class UploadService:
     def upload(
         self,
         data: T.IO[bytes],
-        offset: T.Optional[int] = None,
+        offset: int | None = None,
     ) -> str:
         chunks = self._chunkize_byte_stream(data)
         return self.upload_chunks(chunks, offset=offset)
@@ -123,7 +125,7 @@ class UploadService:
     def upload_chunks(
         self,
         chunks: T.Iterable[bytes],
-        offset: T.Optional[int] = None,
+        offset: int | None = None,
     ) -> str:
         if offset is None:
             offset = self.fetch_offset()
@@ -158,7 +160,7 @@ class UploadService:
         headers = {
             "Authorization": f"OAuth {self.user_access_token}",
         }
-        data: T.Dict[str, T.Union[str, int]] = {
+        data: dict[str, str | int] = {
             "file_handle": file_handle,
             "file_type": self.cluster_filetype.value,
         }
@@ -199,7 +201,7 @@ class FakeUploadService(UploadService):
     def upload_chunks(
         self,
         chunks: T.Iterable[bytes],
-        offset: T.Optional[int] = None,
+        offset: int | None = None,
     ) -> str:
         if offset is None:
             offset = self.fetch_offset()

--- a/mapillary_tools/upload_api_v4.py
+++ b/mapillary_tools/upload_api_v4.py
@@ -8,12 +8,7 @@ import uuid
 
 import requests
 
-from .api_v4 import (
-    request_get,
-    request_post,
-    REQUESTS_TIMEOUT,
-    ClusterFileType,
-)
+from .api_v4 import ClusterFileType, request_get, request_post, REQUESTS_TIMEOUT
 
 MAPILLARY_UPLOAD_ENDPOINT = os.getenv(
     "MAPILLARY_UPLOAD_ENDPOINT", "https://rupload.facebook.com/mapillary_public_uploads"

--- a/mapillary_tools/upload_api_v4.py
+++ b/mapillary_tools/upload_api_v4.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 import io
 import os
 import random
+import sys
 import typing as T
 import uuid
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 import requests
 
@@ -149,7 +155,7 @@ class FakeUploadService(UploadService):
         )
         self._error_ratio = 0.02
 
-    @T.override
+    @override
     def upload_shifted_chunks(
         self,
         shifted_chunks: T.Iterable[bytes],
@@ -176,7 +182,7 @@ class FakeUploadService(UploadService):
                     )
         return uuid.uuid4().hex
 
-    @T.override
+    @override
     def fetch_offset(self) -> int:
         if random.random() <= self._error_ratio:
             raise requests.ConnectionError(

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -268,7 +268,7 @@ class ZipImageSequence:
                     fp,
                     upload_api_v4.ClusterFileType.ZIP,
                     upload_md5sum,
-                    progress=T.cast(dict[str, T.Any], final_progress),
+                    progress=T.cast(T.Dict[str, T.Any], final_progress),
                 )
             if cluster_id is not None:
                 ret[sequence_uuid] = cluster_id

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -237,7 +237,7 @@ class ZipImageSequence:
                 zip_fp,
                 upload_api_v4.ClusterFileType.ZIP,
                 upload_md5sum,
-                progress=T.cast(dict[str, T.Any], final_progress),
+                progress=T.cast(T.Dict[str, T.Any], final_progress),
             )
 
     @classmethod

--- a/tests/cli/upload_api_v4.py
+++ b/tests/cli/upload_api_v4.py
@@ -8,7 +8,7 @@ import requests
 import tqdm
 from mapillary_tools import api_v4, authenticate
 
-from mapillary_tools.upload_api_v4 import DEFAULT_CHUNK_SIZE, UploadService
+from mapillary_tools.upload_api_v4 import UploadService, FakeUploadService
 
 
 LOG = logging.getLogger("mapillary_tools")
@@ -39,9 +39,10 @@ def _parse_args():
     parser.add_argument(
         "--chunk_size",
         type=float,
-        default=DEFAULT_CHUNK_SIZE / (1024 * 1024),
+        default=2,
         help="chunk size in megabytes",
     )
+    parser.add_argument("--dry_run", action="store_true", default=False)
     parser.add_argument("filename")
     parser.add_argument("session_key")
     return parser.parse_args()
@@ -60,17 +61,13 @@ def main():
     user_items = authenticate.fetch_user_items(parsed.user_name)
 
     session_key = parsed.session_key
+    chunk_size = int(parsed.chunk_size * 1024 * 1024)
     user_access_token = user_items.get("user_upload_token", "")
-    service = UploadService(
-        user_access_token,
-        session_key,
-        entity_size,
-        chunk_size=(
-            int(parsed.chunk_size * 1024 * 1024)
-            if parsed.chunk_size is not None
-            else DEFAULT_CHUNK_SIZE
-        ),
-    )
+
+    if parsed.dry_run:
+        service = FakeUploadService(user_access_token, session_key)
+    else:
+        service = UploadService(user_access_token, session_key)
 
     try:
         initial_offset = service.fetch_offset()
@@ -80,9 +77,18 @@ def main():
     LOG.info("Session key: %s", session_key)
     LOG.info("Initial offset: %s", initial_offset)
     LOG.info("Entity size: %d", entity_size)
-    LOG.info("Chunk size: %s MB", service.chunk_size / (1024 * 1024))
+    LOG.info("Chunk size: %s MB", chunk_size / (1024 * 1024))
+
+    def _update_pbar(chunks, pbar):
+        for chunk in chunks:
+            yield chunk
+            pbar.update(len(chunk))
 
     with open(parsed.filename, "rb") as fp:
+        fp.seek(initial_offset, io.SEEK_SET)
+
+        shifted_chunks = service.chunkize_byte_stream(fp, chunk_size)
+
         with tqdm.tqdm(
             total=entity_size,
             initial=initial_offset,
@@ -91,9 +97,10 @@ def main():
             unit_divisor=1024,
             disable=LOG.getEffectiveLevel() <= logging.DEBUG,
         ) as pbar:
-            service.callbacks.append(lambda chunk, resp: pbar.update(len(chunk)))
             try:
-                file_handle = service.upload(fp, initial_offset)
+                file_handle = service.upload_shifted_chunks(
+                    _update_pbar(shifted_chunks, pbar), initial_offset
+                )
             except requests.HTTPError as ex:
                 raise RuntimeError(api_v4.readable_http_error(ex))
             except KeyboardInterrupt:
@@ -107,7 +114,6 @@ def main():
 
     LOG.info("Final offset: %s", final_offset)
     LOG.info("Entity size: %d", entity_size)
-
     LOG.info("File handle: %s", file_handle)
 
 

--- a/tests/cli/upload_api_v4.py
+++ b/tests/cli/upload_api_v4.py
@@ -8,7 +8,7 @@ import requests
 import tqdm
 from mapillary_tools import api_v4, authenticate
 
-from mapillary_tools.upload_api_v4 import UploadService, FakeUploadService
+from mapillary_tools.upload_api_v4 import FakeUploadService, UploadService
 
 
 LOG = logging.getLogger("mapillary_tools")

--- a/tests/unit/test_upload_api_v4.py
+++ b/tests/unit/test_upload_api_v4.py
@@ -11,16 +11,15 @@ def test_upload(setup_upload: py.path.local):
     upload_service = upload_api_v4.FakeUploadService(
         user_access_token="TEST",
         session_key="FOOBAR.txt",
-        chunk_size=1,
     )
     upload_service._error_ratio = 0
     content = b"double_foobar"
-    cluster_id = upload_service.upload(io.BytesIO(content))
+    cluster_id = upload_service.upload_byte_stream(io.BytesIO(content), chunk_size=1)
     assert isinstance(cluster_id, str), cluster_id
     assert (setup_upload.join("FOOBAR.txt").read_binary()) == content
 
     # reupload should not affect the file
-    upload_service.upload(io.BytesIO(content))
+    upload_service.upload_byte_stream(io.BytesIO(content), chunk_size=1)
     assert (setup_upload.join("FOOBAR.txt").read_binary()) == content
 
 
@@ -28,16 +27,15 @@ def test_upload_big_chunksize(setup_upload: py.path.local):
     upload_service = upload_api_v4.FakeUploadService(
         user_access_token="TEST",
         session_key="FOOBAR.txt",
-        chunk_size=1000,
     )
     upload_service._error_ratio = 0
     content = b"double_foobar"
-    cluster_id = upload_service.upload(io.BytesIO(content))
+    cluster_id = upload_service.upload_byte_stream(io.BytesIO(content), chunk_size=1000)
     assert isinstance(cluster_id, str), cluster_id
     assert (setup_upload.join("FOOBAR.txt").read_binary()) == content
 
     # reupload should not affect the file
-    upload_service.upload(io.BytesIO(content))
+    upload_service.upload_byte_stream(io.BytesIO(content), chunk_size=1000)
     assert (setup_upload.join("FOOBAR.txt").read_binary()) == content
 
 

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -209,11 +209,11 @@ def test_upload_blackvue(
         resp = mly_uploader.upload_stream(
             fp,
             upload_api_v4.ClusterFileType.BLACKVUE,
-            "this_is_a_blackvue_checksum",
+            "this_is_a_blackvue.mp4",
         )
     assert resp == "0"
     for mp4_path in setup_upload.listdir():
-        assert os.path.basename(mp4_path) == "mly_tools_this_is_a_blackvue_checksum.mp4"
+        assert os.path.basename(mp4_path) == "this_is_a_blackvue.mp4"
         with open(mp4_path, "rb") as fp:
             assert fp.read() == b"this is a fake video"
 

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -64,8 +64,9 @@ def test_upload_images(setup_unittest_data: py.path.local, setup_upload: py.path
             "filetype": "image",
         },
     ]
-    resp = mly_uploader.upload_images(
-        [types.from_desc(T.cast(T.Any, desc)) for desc in descs]
+    resp = uploader.ZipImageSequence.prepare_images_and_upload(
+        [types.from_desc(T.cast(T.Any, desc)) for desc in descs],
+        mly_uploader,
     )
     assert len(resp) == 1
     assert len(setup_upload.listdir()) == 1
@@ -115,8 +116,9 @@ def test_upload_images_multiple_sequences(
         },
         dry_run=True,
     )
-    resp = mly_uploader.upload_images(
-        [types.from_desc(T.cast(T.Any, desc)) for desc in descs]
+    resp = uploader.ZipImageSequence.prepare_images_and_upload(
+        [types.from_desc(T.cast(T.Any, desc)) for desc in descs],
+        mly_uploader,
     )
     assert len(resp) == 2
     assert len(setup_upload.listdir()) == 2
@@ -180,8 +182,10 @@ def test_upload_zip(
         emitter=emitter,
     )
     for zip_path in zip_dir.listdir():
-        resp = mly_uploader.upload_zipfile(Path(zip_path))
-        assert resp == "0"
+        cluster = uploader.ZipImageSequence.prepare_zipfile_and_upload(
+            Path(zip_path), mly_uploader
+        )
+        assert cluster == "0"
     descs = _validate_zip_dir(setup_upload)
     assert 3 == len(descs)
 


### PR DESCRIPTION
- reduce the usage of emitters which is hard to track
- add `upload_shifted_chunks()` in upload_api_v4.py to work better with progress bar
- Separate `Progress` events to `UploaderProgress` and `SequenecProgress`
- move `finish_upload` to api_v4.py because it's a GraphAPI call