### PR TITLE
refactor: Improve uploader and CAMM mp4 builder

### DIFF
--- a/mapillary_tools/camm/camm_builder.py
+++ b/mapillary_tools/camm/camm_builder.py
@@ -1,7 +1,7 @@
 import io
 import typing as T
 
-from .. import geo, types
+from .. import geo
 from ..mp4 import (
     construct_mp4_parser as cparser,
     mp4_sample_parser as sample_parser,
@@ -23,25 +23,23 @@ def _build_camm_sample(measurement: camm_parser.TelemetryMeasurement) -> bytes:
 
 
 def _create_edit_list_from_points(
-    point_segments: T.Sequence[T.Sequence[geo.Point]],
+    tracks: T.Sequence[T.Sequence[geo.Point]],
     movie_timescale: int,
     media_timescale: int,
 ) -> builder.BoxDict:
     entries: T.List[T.Dict] = []
 
-    non_empty_point_segments = [points for points in point_segments if points]
+    non_empty_tracks = [track for track in tracks if track]
 
-    for idx, points in enumerate(non_empty_point_segments):
-        assert 0 <= points[0].time, (
-            f"expect non-negative point time but got {points[0]}"
-        )
-        assert points[0].time <= points[-1].time, (
-            f"expect points to be sorted but got first point {points[0]} and last point {points[-1]}"
+    for idx, track in enumerate(non_empty_tracks):
+        assert 0 <= track[0].time, f"expect non-negative point time but got {track[0]}"
+        assert track[0].time <= track[-1].time, (
+            f"expect points to be sorted but got first point {track[0]} and last point {track[-1]}"
         )
 
         if idx == 0:
-            if 0 < points[0].time:
-                segment_duration = int(points[0].time * movie_timescale)
+            if 0 < track[0].time:
+                segment_duration = int(track[0].time * movie_timescale)
                 # put an empty edit list entry to skip the initial gap
                 entries.append(
                     {
@@ -53,8 +51,8 @@ def _create_edit_list_from_points(
                     }
                 )
         else:
-            media_time = int(points[0].time * media_timescale)
-            segment_duration = int((points[-1].time - points[0].time) * movie_timescale)
+            media_time = int(track[0].time * media_timescale)
+            segment_duration = int((track[-1].time - track[0].time) * movie_timescale)
             entries.append(
                 {
                     "media_time": media_time,
@@ -70,19 +68,6 @@ def _create_edit_list_from_points(
             "entries": entries,
         },
     }
-
-
-def _multiplex(
-    points: T.Sequence[geo.Point],
-    measurements: T.Optional[T.List[camm_parser.TelemetryMeasurement]] = None,
-) -> T.List[camm_parser.TelemetryMeasurement]:
-    mutiplexed: T.List[camm_parser.TelemetryMeasurement] = [
-        *points,
-        *(measurements or []),
-    ]
-    mutiplexed.sort(key=lambda m: m.time)
-
-    return mutiplexed
 
 
 def convert_telemetry_to_raw_samples(
@@ -237,29 +222,44 @@ def create_camm_trak(
     }
 
 
-def camm_sample_generator2(
-    video_metadata: types.VideoMetadata,
-    telemetry_measurements: T.Optional[T.List[camm_parser.TelemetryMeasurement]] = None,
-):
+def camm_sample_generator2(camm_info: camm_parser.CAMMInfo):
     def _f(
         fp: T.BinaryIO,
         moov_children: T.List[builder.BoxDict],
     ) -> T.Generator[io.IOBase, None, None]:
         movie_timescale = builder.find_movie_timescale(moov_children)
-        # make sure the precision of timedeltas not lower than 0.001 (1ms)
+        # Make sure the precision of timedeltas not lower than 0.001 (1ms)
         media_timescale = max(1000, movie_timescale)
 
-        # points with negative time are skipped
-        # TODO: interpolate first point at time == 0
-        # TODO: measurements with negative times should be skipped too
-        points = [point for point in video_metadata.points if point.time >= 0]
+        # Multiplex points for creating elst
+        track: list[geo.Point] = [
+            *(camm_info.gps or []),
+            *(camm_info.mini_gps or []),
+        ]
+        track.sort(key=lambda p: p.time)
+        if track and track[0].time < 0:
+            track = [p for p in track if p.time >= 0]
+        elst = _create_edit_list_from_points([track], movie_timescale, media_timescale)
 
-        measurements = _multiplex(points, telemetry_measurements)
+        # Multiplex telemetry measurements
+        measurements: list[camm_parser.TelemetryMeasurement] = [
+            *(camm_info.gps or []),
+            *(camm_info.mini_gps or []),
+            *(camm_info.accl or []),
+            *(camm_info.gyro or []),
+            *(camm_info.magn or []),
+        ]
+        measurements.sort(key=lambda m: m.time)
+        if measurements and measurements[0].time < 0:
+            measurements = [m for m in measurements if m.time >= 0]
+
+        # Serialize the telemetry measurements into MP4 samples
         camm_samples = list(
             convert_telemetry_to_raw_samples(measurements, media_timescale)
         )
+
         camm_trak = create_camm_trak(camm_samples, media_timescale)
-        elst = _create_edit_list_from_points([points], movie_timescale, media_timescale)
+
         if T.cast(T.Dict, elst["data"])["entries"]:
             T.cast(T.List[builder.BoxDict], camm_trak["data"]).append(
                 {
@@ -270,18 +270,18 @@ def camm_sample_generator2(
         moov_children.append(camm_trak)
 
         udta_data: T.List[builder.BoxDict] = []
-        if video_metadata.make:
+        if camm_info.make:
             udta_data.append(
                 {
                     "type": b"@mak",
-                    "data": video_metadata.make.encode("utf-8"),
+                    "data": camm_info.make.encode("utf-8"),
                 }
             )
-        if video_metadata.model:
+        if camm_info.model:
             udta_data.append(
                 {
                     "type": b"@mod",
-                    "data": video_metadata.model.encode("utf-8"),
+                    "data": camm_info.model.encode("utf-8"),
                 }
             )
         if udta_data:

--- a/mapillary_tools/camm/camm_builder.py
+++ b/mapillary_tools/camm/camm_builder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import typing as T
 
@@ -27,7 +29,7 @@ def _create_edit_list_from_points(
     movie_timescale: int,
     media_timescale: int,
 ) -> builder.BoxDict:
-    entries: T.List[T.Dict] = []
+    entries: list[dict] = []
 
     non_empty_tracks = [track for track in tracks if track]
 
@@ -225,7 +227,7 @@ def create_camm_trak(
 def camm_sample_generator2(camm_info: camm_parser.CAMMInfo):
     def _f(
         fp: T.BinaryIO,
-        moov_children: T.List[builder.BoxDict],
+        moov_children: list[builder.BoxDict],
     ) -> T.Generator[io.IOBase, None, None]:
         movie_timescale = builder.find_movie_timescale(moov_children)
         # Make sure the precision of timedeltas not lower than 0.001 (1ms)
@@ -269,7 +271,7 @@ def camm_sample_generator2(camm_info: camm_parser.CAMMInfo):
             )
         moov_children.append(camm_trak)
 
-        udta_data: T.List[builder.BoxDict] = []
+        udta_data: list[builder.BoxDict] = []
         if camm_info.make:
             udta_data.append(
                 {

--- a/mapillary_tools/constants.py
+++ b/mapillary_tools/constants.py
@@ -70,3 +70,20 @@ PROMPT_DISABLED: bool = _yes_or_no(os.getenv(_ENV_PREFIX + "PROMPT_DISABLED", "N
 _AUTH_VERIFICATION_DISABLED: bool = _yes_or_no(
     os.getenv(_ENV_PREFIX + "_AUTH_VERIFICATION_DISABLED", "NO")
 )
+
+MAPILLARY_DISABLE_API_LOGGING: bool = _yes_or_no(
+    os.getenv("MAPILLARY_DISABLE_API_LOGGING", "NO")
+)
+MAPILLARY__ENABLE_UPLOAD_HISTORY_FOR_DRY_RUN: bool = _yes_or_no(
+    os.getenv("MAPILLARY__ENABLE_UPLOAD_HISTORY_FOR_DRY_RUN", "NO")
+)
+MAPILLARY__EXPERIMENTAL_ENABLE_IMU: bool = _yes_or_no(
+    os.getenv("MAPILLARY__EXPERIMENTAL_ENABLE_IMU", "NO")
+)
+MAPILLARY_UPLOAD_HISTORY_PATH: str = os.getenv(
+    "MAPILLARY_UPLOAD_HISTORY_PATH",
+    os.path.join(
+        USER_DATA_DIR,
+        "upload_history",
+    ),
+)

--- a/mapillary_tools/geotag/geotag_videos_from_video.py
+++ b/mapillary_tools/geotag/geotag_videos_from_video.py
@@ -23,13 +23,23 @@ class GoProVideoExtractor(GenericVideoExtractor):
         gps_points = gopro_info.gps
         assert gps_points is not None, "must have GPS data extracted"
         if not gps_points:
-            raise exceptions.MapillaryGPXEmptyError("Empty GPS data found")
+            # Instead of raising an exception, return error metadata to tell the file type
+            ex: exceptions.MapillaryDescriptionError = (
+                exceptions.MapillaryGPXEmptyError("Empty GPS data found")
+            )
+            return types.describe_error_metadata(
+                ex, self.video_path, filetype=FileType.GOPRO
+            )
 
         gps_points = T.cast(
             T.List[telemetry.GPSPoint], gpmf_gps_filter.remove_noisy_points(gps_points)
         )
         if not gps_points:
-            raise exceptions.MapillaryGPSNoiseError("GPS is too noisy")
+            # Instead of raising an exception, return error metadata to tell the file type
+            ex = exceptions.MapillaryGPSNoiseError("GPS is too noisy")
+            return types.describe_error_metadata(
+                ex, self.video_path, filetype=FileType.GOPRO
+            )
 
         video_metadata = types.VideoMetadata(
             filename=self.video_path,
@@ -54,7 +64,13 @@ class CAMMVideoExtractor(GenericVideoExtractor):
             )
 
         if not camm_info.gps and not camm_info.mini_gps:
-            raise exceptions.MapillaryGPXEmptyError("Empty GPS data found")
+            # Instead of raising an exception, return error metadata to tell the file type
+            ex: exceptions.MapillaryDescriptionError = (
+                exceptions.MapillaryGPXEmptyError("Empty GPS data found")
+            )
+            return types.describe_error_metadata(
+                ex, self.video_path, filetype=FileType.CAMM
+            )
 
         return types.VideoMetadata(
             filename=self.video_path,
@@ -77,7 +93,13 @@ class BlackVueVideoExtractor(GenericVideoExtractor):
             )
 
         if not blackvue_info.gps:
-            raise exceptions.MapillaryGPXEmptyError("Empty GPS data found")
+            # Instead of raising an exception, return error metadata to tell the file type
+            ex: exceptions.MapillaryDescriptionError = (
+                exceptions.MapillaryGPXEmptyError("Empty GPS data found")
+            )
+            return types.describe_error_metadata(
+                ex, self.video_path, filetype=FileType.BLACKVUE
+            )
 
         video_metadata = types.VideoMetadata(
             filename=self.video_path,

--- a/mapillary_tools/history.py
+++ b/mapillary_tools/history.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import string
 import typing as T
 from pathlib import Path
@@ -10,13 +9,6 @@ from . import constants, types
 JSONDict = T.Dict[str, T.Union[str, int, float, None]]
 
 LOG = logging.getLogger(__name__)
-MAPILLARY_UPLOAD_HISTORY_PATH = os.getenv(
-    "MAPILLARY_UPLOAD_HISTORY_PATH",
-    os.path.join(
-        constants.USER_DATA_DIR,
-        "upload_history",
-    ),
-)
 
 
 def _validate_hexdigits(md5sum: str):
@@ -35,14 +27,14 @@ def history_desc_path(md5sum: str) -> Path:
     basename = md5sum[2:]
     assert basename, f"Invalid md5sum {md5sum}"
     return (
-        Path(MAPILLARY_UPLOAD_HISTORY_PATH)
+        Path(constants.MAPILLARY_UPLOAD_HISTORY_PATH)
         .joinpath(subfolder)
         .joinpath(f"{basename}.json")
     )
 
 
 def is_uploaded(md5sum: str) -> bool:
-    if not MAPILLARY_UPLOAD_HISTORY_PATH:
+    if not constants.MAPILLARY_UPLOAD_HISTORY_PATH:
         return False
     return history_desc_path(md5sum).is_file()
 
@@ -53,7 +45,7 @@ def write_history(
     summary: JSONDict,
     metadatas: T.Optional[T.Sequence[types.Metadata]] = None,
 ) -> None:
-    if not MAPILLARY_UPLOAD_HISTORY_PATH:
+    if not constants.MAPILLARY_UPLOAD_HISTORY_PATH:
         return
     path = history_desc_path(md5sum)
     LOG.debug("Writing upload history: %s", path)

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -696,7 +696,7 @@ def _upload_zipfiles(
         }
         try:
             cluster_id = uploader.ZipImageSequence.prepare_zipfile_and_upload(
-                zip_path, mly_uploader, progress=progress
+                zip_path, mly_uploader, progress=T.cast(T.Dict[str, T.Any], progress)
             )
         except Exception as ex:
             raise UploadError(ex) from ex

--- a/mapillary_tools/upload_api_v4.py
+++ b/mapillary_tools/upload_api_v4.py
@@ -32,7 +32,6 @@ class UploadService:
     user_access_token: str
     session_key: str
     cluster_filetype: ClusterFileType
-    chunk_size: int
 
     MIME_BY_CLUSTER_TYPE: dict[ClusterFileType, str] = {
         ClusterFileType.ZIP: "application/zip",
@@ -96,7 +95,7 @@ class UploadService:
         self,
         stream: T.IO[bytes],
         offset: int | None = None,
-        chunk_size: int = 2 * 1024 * 1024,
+        chunk_size: int = 2 * 1024 * 1024,  # 2MB
     ) -> str:
         if offset is None:
             offset = self.fetch_offset()

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -282,6 +282,7 @@ class ZipImageSequence:
                     session_key,
                     progress=T.cast(T.Dict[str, T.Any], final_progress),
                 )
+
             if cluster_id is not None:
                 ret[sequence_uuid] = cluster_id
         return ret
@@ -419,6 +420,9 @@ class Uploader:
 
             progress["offset"] += len(chunk)
             progress["chunk_size"] = len(chunk)
+            # Whenever a chunk is uploaded, reset retries
+            progress["retries"] = 0
+
             if self.emitter:
                 self.emitter.emit("upload_progress", progress)
 

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -209,10 +209,10 @@ class ZipImageSequence:
         cls,
         zip_path: Path,
         uploader: Uploader,
-        progress: SequenceProgress | None = None,
+        progress: dict[str, T.Any] | None = None,
     ) -> str | None:
         if progress is None:
-            progress = T.cast(SequenceProgress, {})
+            progress = {}
 
         with zipfile.ZipFile(zip_path) as ziph:
             namelist = ziph.namelist()
@@ -227,8 +227,7 @@ class ZipImageSequence:
             with zip_path.open("rb") as zip_fp:
                 upload_md5sum = utils.md5sum_fp(zip_fp).hexdigest()
 
-        final_progress: SequenceProgress = {
-            **progress,
+        sequence_progress: SequenceProgress = {
             "sequence_image_count": len(namelist),
             "file_type": types.FileType.ZIP.value,
             "md5sum": upload_md5sum,
@@ -241,7 +240,8 @@ class ZipImageSequence:
                 zip_fp,
                 upload_api_v4.ClusterFileType.ZIP,
                 session_key,
-                progress=T.cast(T.Dict[str, T.Any], final_progress),
+                # Send the copy of the input progress to each upload session, to avoid modifying the original one
+                progress=T.cast(T.Dict[str, T.Any], {**progress, **sequence_progress}),
             )
 
     @classmethod
@@ -249,17 +249,16 @@ class ZipImageSequence:
         cls,
         image_metadatas: T.Sequence[types.ImageMetadata],
         uploader: Uploader,
-        progress: SequenceProgress | None = None,
+        progress: dict[str, T.Any] | None = None,
     ) -> dict[str, str]:
         if progress is None:
-            progress = T.cast(SequenceProgress, {})
+            progress = {}
 
         _validate_metadatas(image_metadatas)
         sequences = types.group_and_sort_images(image_metadatas)
         ret: dict[str, str] = {}
         for sequence_idx, (sequence_uuid, sequence) in enumerate(sequences.items()):
-            final_progress: SequenceProgress = {
-                **progress,
+            sequence_progress: SequenceProgress = {
                 "sequence_idx": sequence_idx,
                 "total_sequence_count": len(sequences),
                 "sequence_image_count": len(sequence),
@@ -270,7 +269,7 @@ class ZipImageSequence:
             with tempfile.NamedTemporaryFile() as fp:
                 upload_md5sum = cls.zip_sequence_fp(sequence, fp)
 
-                final_progress["md5sum"] = upload_md5sum
+                sequence_progress["md5sum"] = upload_md5sum
 
                 session_key = _session_key(
                     upload_md5sum, upload_api_v4.ClusterFileType.ZIP
@@ -280,7 +279,10 @@ class ZipImageSequence:
                     fp,
                     upload_api_v4.ClusterFileType.ZIP,
                     session_key,
-                    progress=T.cast(T.Dict[str, T.Any], final_progress),
+                    # Send the copy of the input progress to each upload session, to avoid modifying the original one
+                    progress=T.cast(
+                        T.Dict[str, T.Any], {**progress, **sequence_progress}
+                    ),
                 )
 
             if cluster_id is not None:

--- a/tests/unit/test_camm_parser.py
+++ b/tests/unit/test_camm_parser.py
@@ -3,7 +3,7 @@ import io
 import typing as T
 from pathlib import Path
 
-from mapillary_tools import geo, telemetry, types
+from mapillary_tools import geo, telemetry, types, upload
 from mapillary_tools.camm import camm_builder, camm_parser
 from mapillary_tools.mp4 import construct_mp4_parser as cparser, simple_mp4_builder
 
@@ -38,6 +38,7 @@ def test_filter_points_by_edit_list():
     )
 
 
+# TODO: use CAMMInfo as input
 def encode_decode_empty_camm_mp4(metadata: types.VideoMetadata) -> types.VideoMetadata:
     movie_timescale = 1_000_000
 
@@ -56,8 +57,9 @@ def encode_decode_empty_camm_mp4(metadata: types.VideoMetadata) -> types.VideoMe
         {"type": b"moov", "data": [mvhd]},
     ]
     src = cparser.MP4WithoutSTBLBuilderConstruct.build_boxlist(empty_mp4)
+    input_camm_info = upload._prepare_camm_info(metadata)
     target_fp = simple_mp4_builder.transform_mp4(
-        io.BytesIO(src), camm_builder.camm_sample_generator2(metadata)
+        io.BytesIO(src), camm_builder.camm_sample_generator2(input_camm_info)
     )
 
     # extract points


### PR DESCRIPTION
General improvements on uploads and CAMM mp4 builder:

- CAMM builder now accepts `CAMMInfo` instead of `VideoMetadata` (reduce dependencies)
- Report progress every 10 seconds in verbose/debug mode, so less verbose
- Return filetype in error metadatas in all VideoExtractors, so videos can be correctly recognized in the process summery report
- Reset retries=0 when a chunk is successfully uploaded
- Move all envvars to `constants.py`
