### PR TITLE
fix: distinguish GoPro and other cameras using the same gpmd format

### DIFF
--- a/mapillary_tools/geotag/geotag_from_generic.py
+++ b/mapillary_tools/geotag/geotag_from_generic.py
@@ -34,7 +34,7 @@ class GeotagImagesFromGeneric(abc.ABC, T.Generic[TImageExtractor]):
     """
 
     def __init__(
-        self, image_paths: T.Sequence[Path], num_processes: int | None
+        self, image_paths: T.Sequence[Path], num_processes: int | None = None
     ) -> None:
         self.image_paths = image_paths
         self.num_processes = num_processes
@@ -109,7 +109,7 @@ class GeotagVideosFromGeneric(abc.ABC, T.Generic[TVideoExtractor]):
     """
 
     def __init__(
-        self, video_paths: T.Sequence[Path], num_processes: int | None
+        self, video_paths: T.Sequence[Path], num_processes: int | None = None
     ) -> None:
         self.video_paths = video_paths
         self.num_processes = num_processes

--- a/mapillary_tools/gpmf/gpmf_parser.py
+++ b/mapillary_tools/gpmf/gpmf_parser.py
@@ -219,7 +219,11 @@ def extract_camera_model(fp: T.BinaryIO) -> str:
         if _contains_gpmd_description(track):
             gpmd_samples = _filter_gpmd_samples(track)
             dvnm_by_dvid: dict[int, bytes] = {}
-            _load_telemetry_from_samples(fp, gpmd_samples, dvnm_by_dvid=dvnm_by_dvid)
+            device_found = _load_telemetry_from_samples(
+                fp, gpmd_samples, dvnm_by_dvid=dvnm_by_dvid
+            )
+            if not device_found:
+                return ""
             return _extract_camera_model_from_devices(dvnm_by_dvid)
 
     return ""


### PR DESCRIPTION
This is to distinguish GoPro and other cameras that using the same GPMD format.

If we can not find even a single `DEVC` in the "gpmd" container, we consider it not a GoPro video. Some cameras, .e.g. VANTRUE N2S 4K Dashcam, for example, do use "gpmd" description but they are not using the GPMF format.