### PR TITLE
Use -fast parameter when running exiftool

### DIFF
--- a/mapillary_tools/exiftool_runner.py
+++ b/mapillary_tools/exiftool_runner.py
@@ -38,6 +38,7 @@ class ExiftoolRunner:
     def _build_args_read_stdin(self) -> list[str]:
         args: list[str] = [
             self.exiftool_path,
+            "-fast",
             "-q",
             "-n",  # Disable print conversion
             "-X",  # XML output


### PR DESCRIPTION
Just adding the -fast parameter for faster parsing.
<img width="978" alt="Screenshot 2025-05-15 at 13 54 21" src="https://github.com/user-attachments/assets/abd60ea7-6a0d-44a8-8114-17bfcdf9ed48" />
