### PR TITLE
feat: support uploading images file by file

### DIFF
--- a/mapillary_tools/api_v4.py
+++ b/mapillary_tools/api_v4.py
@@ -25,6 +25,7 @@ class ClusterFileType(enum.Enum):
     ZIP = "zip"
     BLACKVUE = "mly_blackvue_video"
     CAMM = "mly_camm_video"
+    MLY_BUNDLE_MANIFEST = "mly_bundle_manifest"
 
 
 class HTTPSystemCertsAdapter(HTTPAdapter):

--- a/mapillary_tools/constants.py
+++ b/mapillary_tools/constants.py
@@ -89,3 +89,5 @@ MAPILLARY_UPLOAD_HISTORY_PATH: str = os.getenv(
         "upload_history",
     ),
 )
+
+MAX_IMAGE_UPLOAD_WORKERS = int(os.getenv(_ENV_PREFIX + "MAX_IMAGE_UPLOAD_WORKERS", 64))

--- a/mapillary_tools/types.py
+++ b/mapillary_tools/types.py
@@ -6,10 +6,16 @@ import enum
 import hashlib
 import json
 import os
+import sys
 import typing as T
 import uuid
 from pathlib import Path
 from typing import Literal, TypedDict
+
+if sys.version_info >= (3, 12):
+    from typing import NotRequired, Required
+else:
+    from typing_extensions import NotRequired, Required
 
 import jsonschema
 
@@ -144,7 +150,7 @@ class UserItem(TypedDict, total=False):
     # Not in use. Keep here for back-compatibility
     MAPSettingsUsername: str
     MAPSettingsUserKey: str
-    user_upload_token: T.Required[str]
+    user_upload_token: Required[str]
 
 
 class _CompassHeading(TypedDict, total=True):
@@ -152,65 +158,49 @@ class _CompassHeading(TypedDict, total=True):
     MagneticHeading: float
 
 
-class _ImageRequired(TypedDict, total=True):
-    MAPLatitude: float
-    MAPLongitude: float
-    MAPCaptureTime: str
+class _SharedDescription(TypedDict, total=False):
+    filename: Required[str]
+    filetype: Required[str]
+
+    # if None or absent, it will be calculated
+    md5sum: str | None
+    filesize: int | None
 
 
-class _Image(_ImageRequired, total=False):
+class ImageDescription(_SharedDescription, total=False):
+    MAPLatitude: Required[float]
+    MAPLongitude: Required[float]
     MAPAltitude: float
+    MAPCaptureTime: Required[str]
     MAPCompassHeading: _CompassHeading
 
-
-class _SequenceOnly(TypedDict, total=False):
-    MAPSequenceUUID: str
-
-
-class MetaProperties(TypedDict, total=False):
     MAPDeviceMake: str
     MAPDeviceModel: str
     MAPGPSAccuracyMeters: float
     MAPCameraUUID: str
     MAPOrientation: int
 
-
-class ImageDescription(_SequenceOnly, _Image, MetaProperties, total=True):
-    # filename is required
-    filename: str
-    # if None or absent, it will be calculated
-    md5sum: str | None
-    filetype: Literal["image"]
-    filesize: int | None
+    # For grouping images in a sequence
+    MAPSequenceUUID: str
 
 
-class _VideoDescriptionRequired(TypedDict, total=True):
-    filename: str
-    md5sum: str | None
-    filetype: str
-    MAPGPSTrack: list[T.Sequence[float | int | None]]
-
-
-class VideoDescription(_VideoDescriptionRequired, total=False):
+class VideoDescription(_SharedDescription, total=False):
+    MAPGPSTrack: Required[list[T.Sequence[float | int | None]]]
     MAPDeviceMake: str
     MAPDeviceModel: str
-    filesize: int | None
 
 
 class _ErrorDescription(TypedDict, total=False):
     # type and message are required
-    type: str
+    type: Required[str]
     message: str
     # vars is optional
     vars: dict
 
 
-class _ImageDescriptionErrorRequired(TypedDict, total=True):
-    filename: str
-    error: _ErrorDescription
-
-
-class ImageDescriptionError(_ImageDescriptionErrorRequired, total=False):
+class ImageDescriptionError(TypedDict, total=False):
+    filename: Required[str]
+    error: Required[_ErrorDescription]
     filetype: str
 
 

--- a/mapillary_tools/types.py
+++ b/mapillary_tools/types.py
@@ -144,7 +144,7 @@ class UserItem(TypedDict, total=False):
     # Not in use. Keep here for back-compatibility
     MAPSettingsUsername: str
     MAPSettingsUserKey: str
-    user_upload_token: str
+    user_upload_token: T.Required[str]
 
 
 class _CompassHeading(TypedDict, total=True):

--- a/mapillary_tools/types.py
+++ b/mapillary_tools/types.py
@@ -10,12 +10,12 @@ import sys
 import typing as T
 import uuid
 from pathlib import Path
-from typing import Literal, TypedDict
+from typing import TypedDict
 
-if sys.version_info >= (3, 12):
-    from typing import NotRequired, Required
+if sys.version_info >= (3, 11):
+    from typing import Required
 else:
-    from typing_extensions import NotRequired, Required
+    from typing_extensions import Required
 
 import jsonschema
 

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -514,7 +514,7 @@ def _gen_upload_videos(
         }
 
         session_key = uploader._session_key(
-            video_metadata.md5sum, upload_api_v4.ClusterFileType.CAMM
+            video_metadata.md5sum, api_v4.ClusterFileType.CAMM
         )
 
         try:
@@ -525,12 +525,16 @@ def _gen_upload_videos(
                 )
 
                 # Upload the mp4 stream
-                cluster_id = mly_uploader.upload_stream(
+                file_handle = mly_uploader.upload_stream(
                     T.cast(T.IO[bytes], camm_fp),
-                    upload_api_v4.ClusterFileType.CAMM,
                     session_key,
                     progress=T.cast(T.Dict[str, T.Any], progress),
                 )
+            cluster_id = mly_uploader.finish_upload(
+                file_handle,
+                api_v4.ClusterFileType.CAMM,
+                progress=T.cast(T.Dict[str, T.Any], progress),
+            )
         except Exception as ex:
             yield video_metadata, uploader.UploadResult(error=ex)
         else:

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -22,7 +22,6 @@ from . import (
     ipc,
     telemetry,
     types,
-    upload_api_v4,
     uploader,
     utils,
     VERSION,

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -556,12 +556,7 @@ def _gen_upload_videos(
             "file_type": video_metadata.filetype.value,
             "import_path": str(video_metadata.filename),
             "sequence_md5sum": video_metadata.md5sum,
-            "upload_md5sum": video_metadata.md5sum,
         }
-
-        session_key = uploader._session_key(
-            video_metadata.md5sum, api_v4.ClusterFileType.CAMM
-        )
 
         try:
             with video_metadata.filename.open("rb") as src_fp:
@@ -573,7 +568,6 @@ def _gen_upload_videos(
                 # Upload the mp4 stream
                 file_handle = mly_uploader.upload_stream(
                     T.cast(T.IO[bytes], camm_fp),
-                    session_key,
                     progress=T.cast(T.Dict[str, T.Any], progress),
                 )
             cluster_id = mly_uploader.finish_upload(

--- a/mapillary_tools/upload_api_v4.py
+++ b/mapillary_tools/upload_api_v4.py
@@ -4,9 +4,9 @@ import io
 import os
 import random
 import sys
-from pathlib import Path
 import typing as T
 import uuid
+from pathlib import Path
 
 if sys.version_info >= (3, 12):
     from typing import override

--- a/mapillary_tools/upload_api_v4.py
+++ b/mapillary_tools/upload_api_v4.py
@@ -14,7 +14,7 @@ else:
 
 import requests
 
-from .api_v4 import ClusterFileType, request_get, request_post, REQUESTS_TIMEOUT
+from .api_v4 import request_get, request_post, REQUESTS_TIMEOUT
 
 MAPILLARY_UPLOAD_ENDPOINT = os.getenv(
     "MAPILLARY_UPLOAD_ENDPOINT", "https://rupload.facebook.com/mapillary_public_uploads"
@@ -31,24 +31,14 @@ UPLOAD_REQUESTS_TIMEOUT = (30 * 60, 30 * 60)  # 30 minutes
 class UploadService:
     user_access_token: str
     session_key: str
-    cluster_filetype: ClusterFileType
-
-    MIME_BY_CLUSTER_TYPE: dict[ClusterFileType, str] = {
-        ClusterFileType.ZIP: "application/zip",
-        ClusterFileType.BLACKVUE: "video/mp4",
-        ClusterFileType.CAMM: "video/mp4",
-    }
 
     def __init__(
         self,
         user_access_token: str,
         session_key: str,
-        cluster_filetype: ClusterFileType,
     ):
         self.user_access_token = user_access_token
         self.session_key = session_key
-        # Validate the input
-        self.cluster_filetype = cluster_filetype
 
     def fetch_offset(self) -> int:
         headers = {
@@ -124,7 +114,6 @@ class UploadService:
             "Authorization": f"OAuth {self.user_access_token}",
             "Offset": f"{offset}",
             "X-Entity-Name": self.session_key,
-            "X-Entity-Type": self.MIME_BY_CLUSTER_TYPE[self.cluster_filetype],
         }
         url = f"{MAPILLARY_UPLOAD_ENDPOINT}/{self.session_key}"
         resp = request_post(

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -393,7 +393,9 @@ class ZipImageSequence:
 
         uploader.emitter.emit("upload_start", progress)
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=constants.MAX_IMAGE_UPLOAD_WORKERS
+        ) as executor:
             image_file_handles = list(executor.map(_upload_image, sequence))
 
         manifest = {

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -641,7 +641,9 @@ class Uploader:
 
         return cluster_id
 
-    def _maybe_emit(self, event: EventName, progress: dict[str, T.Any]):
+    def _maybe_emit(
+        self, event: EventName, progress: dict[str, T.Any] | UploaderProgress
+    ):
         if not self.emittion_disabled:
             return self.emitter.emit(event, progress)
 

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -368,7 +368,7 @@ class ZipImageSequence:
         def _upload_image(image_metadata: types.ImageMetadata) -> str:
             nonlocal total_image_bytes
 
-            mutable_progress: dict[str, T.Any] = {
+            mutable_progress = {
                 **progress,
                 "filename": str(image_metadata.filename),
             }

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -329,8 +329,6 @@ class ZipImageSequence:
                 "file_type": types.FileType.IMAGE.value,
             }
 
-            mutable_progress: dict[str, T.Any] = {**progress, **sequence_progress}
-
             try:
                 _validate_metadatas(sequence)
             except Exception as ex:
@@ -352,6 +350,8 @@ class ZipImageSequence:
                 upload_session_key = _session_key(
                     upload_md5sum, api_v4.ClusterFileType.ZIP
                 )
+
+                mutable_progress: dict[str, T.Any] = {**progress, **sequence_progress}
 
                 try:
                     file_handle = uploader.upload_stream(

--- a/tests/integration/test_gopro.py
+++ b/tests/integration/test_gopro.py
@@ -8,12 +8,12 @@ import py.path
 import pytest
 
 from .fixtures import (
+    assert_same_image_descs,
     EXECUTABLE,
     IS_FFMPEG_INSTALLED,
     run_exiftool_and_generate_geotag_args,
     setup_config,
     setup_upload,
-    verify_descs,
 )
 
 
@@ -26,6 +26,8 @@ TEST_ENVS = {
 }
 EXPECTED_DESCS: T.List[T.Any] = [
     {
+        "filename": "hero8.mp4/hero8_NA_000001.jpg",
+        "filetype": "image",
         "MAPAltitude": 9540.24,
         "MAPCaptureTime": "2019_11_18_15_41_12_354",
         "MAPCompassHeading": {
@@ -36,9 +38,11 @@ EXPECTED_DESCS: T.List[T.Any] = [
         "MAPLongitude": -129.2943386,
         "MAPDeviceMake": "GoPro",
         "MAPDeviceModel": "HERO8 Black",
-        "filename": "hero8.mp4/hero8_NA_000001.jpg",
+        "MAPFilename": "hero8_NA_000001.jpg",
     },
     {
+        "filename": "hero8.mp4/hero8_NA_000002.jpg",
+        "filetype": "image",
         "MAPAltitude": 7112.573717404068,
         "MAPCaptureTime": "2019_11_18_15_41_14_354",
         "MAPCompassHeading": {
@@ -49,9 +53,11 @@ EXPECTED_DESCS: T.List[T.Any] = [
         "MAPLongitude": -126.85929159704702,
         "MAPDeviceMake": "GoPro",
         "MAPDeviceModel": "HERO8 Black",
-        "filename": "hero8.mp4/hero8_NA_000002.jpg",
+        "MAPFilename": "hero8_NA_000002.jpg",
     },
     {
+        "filename": "hero8.mp4/hero8_NA_000003.jpg",
+        "filetype": "image",
         "MAPAltitude": 7463.642846094319,
         "MAPCaptureTime": "2019_11_18_15_41_16_354",
         "MAPCompassHeading": {
@@ -62,9 +68,11 @@ EXPECTED_DESCS: T.List[T.Any] = [
         "MAPLongitude": -127.18475264566939,
         "MAPDeviceMake": "GoPro",
         "MAPDeviceModel": "HERO8 Black",
-        "filename": "hero8.mp4/hero8_NA_000003.jpg",
+        "MAPFilename": "hero8_NA_000003.jpg",
     },
     {
+        "filename": "hero8.mp4/hero8_NA_000004.jpg",
+        "filetype": "image",
         "MAPAltitude": 6909.8168472111465,
         "MAPCaptureTime": "2019_11_18_15_41_18_354",
         "MAPCompassHeading": {
@@ -75,9 +83,11 @@ EXPECTED_DESCS: T.List[T.Any] = [
         "MAPLongitude": -126.65905680405231,
         "MAPDeviceMake": "GoPro",
         "MAPDeviceModel": "HERO8 Black",
-        "filename": "hero8.mp4/hero8_NA_000004.jpg",
+        "MAPFilename": "hero8_NA_000004.jpg",
     },
     {
+        "filename": "hero8.mp4/hero8_NA_000005.jpg",
+        "filetype": "image",
         "MAPAltitude": 7212.594480737465,
         "MAPCaptureTime": "2019_11_18_15_41_20_354",
         "MAPCompassHeading": {
@@ -88,9 +98,11 @@ EXPECTED_DESCS: T.List[T.Any] = [
         "MAPLongitude": -126.93688762007304,
         "MAPDeviceMake": "GoPro",
         "MAPDeviceModel": "HERO8 Black",
-        "filename": "hero8.mp4/hero8_NA_000005.jpg",
+        "MAPFilename": "hero8_NA_000005.jpg",
     },
     {
+        "filename": "hero8.mp4/hero8_NA_000006.jpg",
+        "filetype": "image",
         "MAPAltitude": 7274.361994963208,
         "MAPCaptureTime": "2019_11_18_15_41_22_354",
         "MAPCompassHeading": {
@@ -101,7 +113,7 @@ EXPECTED_DESCS: T.List[T.Any] = [
         "MAPLongitude": -126.98833423074615,
         "MAPDeviceMake": "GoPro",
         "MAPDeviceModel": "HERO8 Black",
-        "filename": "hero8.mp4/hero8_NA_000006.jpg",
+        "MAPFilename": "hero8_NA_000006.jpg",
     },
 ]
 
@@ -140,7 +152,7 @@ def test_process_gopro_hero8(
     for expected_desc in expected_descs:
         expected_desc["filename"] = str(sample_dir.join(expected_desc["filename"]))
 
-    verify_descs(expected_descs, Path(desc_path))
+    assert_same_image_descs(Path(desc_path), expected_descs)
 
 
 @pytest.mark.usefixtures("setup_config")

--- a/tests/integration/test_history.py
+++ b/tests/integration/test_history.py
@@ -47,18 +47,19 @@ def test_upload_gopro(
         shell=True,
     )
     assert x.returncode == 0, x.stderr
-    assert len(setup_upload.listdir()) == 1, (
+    assert len(setup_upload.listdir()) == 2, (
         f"should be uploaded for the first time but got {setup_upload.listdir()}"
     )
     for upload in setup_upload.listdir():
-        upload.remove()
-    assert len(setup_upload.listdir()) == 0
+        if upload.basename != "file_handles":
+            upload.remove()
+    assert len(setup_upload.listdir()) == 1
 
     x = subprocess.run(
         f"{EXECUTABLE} process_and_upload --skip_process_errors {UPLOAD_FLAGS} {str(video_dir)}",
         shell=True,
     )
     assert x.returncode == 0, x.stderr
-    assert len(setup_upload.listdir()) == 0, (
+    assert len(setup_upload.listdir()) == 1, (
         "should NOT upload because it is uploaded already"
     )

--- a/tests/integration/test_process.py
+++ b/tests/integration/test_process.py
@@ -9,13 +9,13 @@ import py.path
 import pytest
 
 from .fixtures import (
+    assert_contains_image_descs,
     EXECUTABLE,
     IS_FFMPEG_INSTALLED,
     run_exiftool_and_generate_geotag_args,
     setup_config,
     setup_data,
     validate_and_extract_zip,
-    verify_descs,
 )
 
 
@@ -25,6 +25,7 @@ _DEFAULT_EXPECTED_DESCS = {
     "DSC00001.JPG": {
         "filename": "DSC00001.JPG",
         "filetype": "image",
+        "MAPFilename": "DSC00001.JPG",
         "MAPLatitude": 45.5169031,
         "MAPLongitude": -122.572765,
         "MAPCaptureTime": "2018_06_08_20_24_11_000",
@@ -37,6 +38,7 @@ _DEFAULT_EXPECTED_DESCS = {
     "DSC00497.JPG": {
         "filename": "DSC00497.JPG",
         "filetype": "image",
+        "MAPFilename": "DSC00497.JPG",
         "MAPLatitude": 45.5107231,
         "MAPLongitude": -122.5760514,
         "MAPCaptureTime": "2018_06_08_20_32_28_000",
@@ -49,6 +51,7 @@ _DEFAULT_EXPECTED_DESCS = {
     "V0370574.JPG": {
         "filename": "V0370574.JPG",
         "filetype": "image",
+        "MAPFilename": "V0370574.JPG",
         "MAPLatitude": -1.0169444,
         "MAPLongitude": -1.0169444,
         "MAPCaptureTime": "2018_07_27_11_32_14_000",
@@ -58,7 +61,9 @@ _DEFAULT_EXPECTED_DESCS = {
         "MAPOrientation": 1,
     },
     "adobe_coords.jpg": {
+        "filename": "adobe_coords.jpg",
         "filetype": "image",
+        "MAPFilename": "adobe_coords.jpg",
         "MAPLatitude": -0.0702668,
         "MAPLongitude": 34.3819352,
         "MAPCaptureTime": "2019_07_16_10_26_11_000",
@@ -94,23 +99,20 @@ def test_process_images_with_defaults(
     x = subprocess.run(args, shell=True)
 
     assert x.returncode == 0, x.stderr
-    verify_descs(
+    assert_contains_image_descs(
+        Path(setup_data, "mapillary_image_description.json"),
         [
             {
                 **_DEFAULT_EXPECTED_DESCS["DSC00001.JPG"],
-                "filename": str(Path(setup_data, "images", "DSC00001.JPG")),
             },
             {
                 **_DEFAULT_EXPECTED_DESCS["DSC00497.JPG"],
-                "filename": str(Path(setup_data, "images", "DSC00497.JPG")),
             },
             {
                 **_DEFAULT_EXPECTED_DESCS["V0370574.JPG"],
-                "filename": str(Path(setup_data, "images", "V0370574.JPG")),
                 "MAPCaptureTime": _local_to_utc("2018-07-27T11:32:14"),
             },
         ],
-        Path(setup_data, "mapillary_image_description.json"),
     )
 
 
@@ -124,7 +126,8 @@ def test_time_with_offset(setup_data: py.path.local, use_exiftool: bool = False)
         args = run_exiftool_and_generate_geotag_args(setup_data, args)
     x = subprocess.run(args, shell=True)
     assert x.returncode == 0, x.stderr
-    verify_descs(
+    assert_contains_image_descs(
+        Path(setup_data, "mapillary_image_description.json"),
         [
             {
                 **_DEFAULT_EXPECTED_DESCS["DSC00001.JPG"],
@@ -142,7 +145,6 @@ def test_time_with_offset(setup_data: py.path.local, use_exiftool: bool = False)
                 "MAPCaptureTime": _local_to_utc("2018-07-27T11:32:16.500"),
             },
         ],
-        Path(setup_data, "mapillary_image_description.json"),
     )
 
     args = f"{EXECUTABLE} process --file_types=image {PROCESS_FLAGS} {setup_data} --offset_time=-1.0"
@@ -150,7 +152,8 @@ def test_time_with_offset(setup_data: py.path.local, use_exiftool: bool = False)
         args = run_exiftool_and_generate_geotag_args(setup_data, args)
     x = subprocess.run(args, shell=True)
     assert x.returncode == 0, x.stderr
-    verify_descs(
+    assert_contains_image_descs(
+        Path(setup_data, "mapillary_image_description.json"),
         [
             {
                 **_DEFAULT_EXPECTED_DESCS["DSC00001.JPG"],
@@ -168,7 +171,6 @@ def test_time_with_offset(setup_data: py.path.local, use_exiftool: bool = False)
                 "MAPCaptureTime": _local_to_utc("2018-07-27T11:32:13.000"),
             },
         ],
-        Path(setup_data, "mapillary_image_description.json"),
     )
 
 
@@ -201,9 +203,9 @@ def test_process_images_with_overwrite_all_EXIF_tags(
             "MAPCaptureTime": _local_to_utc("2018-07-27T11:32:16.500"),
         },
     ]
-    verify_descs(
-        expected_descs,
+    assert_contains_image_descs(
         Path(setup_data, "mapillary_image_description.json"),
+        expected_descs,
     )
 
     args = f"{EXECUTABLE} process --file_types=image {PROCESS_FLAGS} {setup_data}"
@@ -211,9 +213,9 @@ def test_process_images_with_overwrite_all_EXIF_tags(
         args = run_exiftool_and_generate_geotag_args(setup_data, args)
     x = subprocess.run(args, shell=True)
     assert x.returncode == 0, x.stderr
-    verify_descs(
-        expected_descs,
+    assert_contains_image_descs(
         Path(setup_data, "mapillary_image_description.json"),
+        expected_descs,
     )
 
 
@@ -232,7 +234,8 @@ def test_angle_with_offset(setup_data: py.path.local, use_exiftool: bool = False
     x = subprocess.run(args, shell=True)
     assert x.returncode == 0, x.stderr
 
-    verify_descs(
+    assert_contains_image_descs(
+        Path(setup_data, "mapillary_image_description.json"),
         [
             {
                 **_DEFAULT_EXPECTED_DESCS["DSC00001.JPG"],
@@ -260,7 +263,6 @@ def test_angle_with_offset(setup_data: py.path.local, use_exiftool: bool = False
                 },
             },
         ],
-        Path(setup_data, "mapillary_image_description.json"),
     )
 
 
@@ -271,7 +273,8 @@ def test_angle_with_offset_with_exiftool(setup_data: py.path.local):
 def test_parse_adobe_coordinates(setup_data: py.path.local):
     args = f"{EXECUTABLE} process --file_types=image {PROCESS_FLAGS} {setup_data}/adobe_coords"
     x = subprocess.run(args, shell=True)
-    verify_descs(
+    assert_contains_image_descs(
+        Path(setup_data, "adobe_coords/mapillary_image_description.json"),
         [
             {
                 "filename": str(Path(setup_data, "adobe_coords", "adobe_coords.jpg")),
@@ -285,7 +288,6 @@ def test_parse_adobe_coordinates(setup_data: py.path.local):
                 "MAPOrientation": 1,
             }
         ],
-        Path(setup_data, "adobe_coords/mapillary_image_description.json"),
     )
 
 
@@ -385,7 +387,8 @@ def test_geotagging_images_from_gpx(setup_data: py.path.local):
 """,
         shell=True,
     )
-    verify_descs(
+    assert_contains_image_descs(
+        Path(images, "mapillary_image_description.json"),
         [
             {
                 **_DEFAULT_EXPECTED_DESCS["DSC00001.JPG"],
@@ -410,7 +413,6 @@ def test_geotagging_images_from_gpx(setup_data: py.path.local):
                 },
             },
         ],
-        Path(images, "mapillary_image_description.json"),
     )
 
 
@@ -424,7 +426,8 @@ def test_geotagging_images_from_gpx_with_offset(setup_data: py.path.local):
         shell=True,
     )
     assert x.returncode == 0, x.stderr
-    verify_descs(
+    assert_contains_image_descs(
+        Path(setup_data, "mapillary_image_description.json"),
         [
             {
                 **_DEFAULT_EXPECTED_DESCS["DSC00001.JPG"],
@@ -451,7 +454,6 @@ def test_geotagging_images_from_gpx_with_offset(setup_data: py.path.local):
                 },
             },
         ],
-        Path(setup_data, "mapillary_image_description.json"),
     )
 
 
@@ -464,7 +466,8 @@ def test_geotagging_images_from_gpx_use_gpx_start_time(setup_data: py.path.local
         shell=True,
     )
     assert x.returncode == 0, x.stderr
-    verify_descs(
+    assert_contains_image_descs(
+        Path(setup_data, "mapillary_image_description.json"),
         [
             {
                 **_DEFAULT_EXPECTED_DESCS["DSC00001.JPG"],
@@ -491,7 +494,6 @@ def test_geotagging_images_from_gpx_use_gpx_start_time(setup_data: py.path.local
                 },
             },
         ],
-        Path(setup_data, "mapillary_image_description.json"),
     )
 
 
@@ -506,7 +508,8 @@ def test_geotagging_images_from_gpx_use_gpx_start_time_with_offset(
         shell=True,
     )
     assert x.returncode == 0, x.stderr
-    verify_descs(
+    assert_contains_image_descs(
+        Path(setup_data, "mapillary_image_description.json"),
         [
             {
                 **_DEFAULT_EXPECTED_DESCS["DSC00001.JPG"],
@@ -533,7 +536,6 @@ def test_geotagging_images_from_gpx_use_gpx_start_time_with_offset(
                 },
             },
         ],
-        Path(setup_data, "mapillary_image_description.json"),
     )
 
 
@@ -711,7 +713,8 @@ def test_video_process_sample_with_distance(setup_data: py.path.local):
             shell=True,
         )
         assert x.returncode == 0, x.stderr
-        verify_descs(
+        assert_contains_image_descs(
+            desc_path,
             [
                 {
                     "filename": str(
@@ -780,7 +783,6 @@ def test_video_process_sample_with_distance(setup_data: py.path.local):
                     "MAPOrientation": 1,
                 },
             ],
-            desc_path,
         )
 
 

--- a/tests/unit/test_upload_api_v4.py
+++ b/tests/unit/test_upload_api_v4.py
@@ -11,7 +11,6 @@ def test_upload(setup_upload: py.path.local):
     upload_service = upload_api_v4.FakeUploadService(
         user_access_token="TEST",
         session_key="FOOBAR.txt",
-        cluster_filetype=upload_api_v4.ClusterFileType.ZIP,
     )
     upload_service._error_ratio = 0
     content = b"double_foobar"
@@ -28,7 +27,6 @@ def test_upload_big_chunksize(setup_upload: py.path.local):
     upload_service = upload_api_v4.FakeUploadService(
         user_access_token="TEST",
         session_key="FOOBAR.txt",
-        cluster_filetype=upload_api_v4.ClusterFileType.ZIP,
     )
     upload_service._error_ratio = 0
     content = b"double_foobar"
@@ -45,7 +43,6 @@ def test_upload_chunks(setup_upload: py.path.local):
     upload_service = upload_api_v4.FakeUploadService(
         user_access_token="TEST",
         session_key="FOOBAR2.txt",
-        cluster_filetype=upload_api_v4.ClusterFileType.ZIP,
     )
     upload_service._error_ratio = 0
 

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -8,7 +8,7 @@ import py.path
 
 import pytest
 
-from mapillary_tools import types, upload_api_v4, uploader, utils
+from mapillary_tools import types, upload_api_v4, uploader, utils, api_v4
 
 from ..integration.fixtures import setup_upload, validate_and_extract_zip
 
@@ -211,12 +211,14 @@ def test_upload_blackvue(
     with open(blackvue_path, "wb") as fp:
         fp.write(b"this is a fake video")
     with Path(blackvue_path).open("rb") as fp:
-        resp = mly_uploader.upload_stream(
+        file_handle = mly_uploader.upload_stream(
             fp,
-            upload_api_v4.ClusterFileType.BLACKVUE,
             "this_is_a_blackvue.mp4",
         )
-    assert resp == "0"
+    cluster_id = mly_uploader.finish_upload(
+        file_handle, api_v4.ClusterFileType.BLACKVUE
+    )
+    assert cluster_id == "0"
     for mp4_path in setup_upload.listdir():
         assert os.path.basename(mp4_path) == "this_is_a_blackvue.mp4"
         with open(mp4_path, "rb") as fp:

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -114,9 +114,7 @@ def test_upload_images_multiple_sequences(
 
 
 def test_upload_zip(
-    setup_unittest_data: py.path.local,
-    setup_upload: py.path.local,
-    emitter=None,
+    setup_unittest_data: py.path.local, setup_upload: py.path.local, emitter=None
 ):
     test_exif = setup_unittest_data.join("test_exif.jpg")
     setup_unittest_data.join("another_directory").mkdir()
@@ -174,10 +172,7 @@ def test_upload_zip(
     assert 3 == len(actual_descs)
 
 
-def test_upload_blackvue(
-    tmpdir: py.path.local,
-    setup_upload: py.path.local,
-):
+def test_upload_blackvue(tmpdir: py.path.local, setup_upload: py.path.local):
     mly_uploader = uploader.Uploader(
         {
             "user_upload_token": "YOUR_USER_ACCESS_TOKEN",
@@ -204,9 +199,7 @@ def test_upload_blackvue(
 
 
 def test_upload_zip_with_emitter(
-    setup_unittest_data: py.path.local,
-    tmpdir: py.path.local,
-    setup_upload: py.path.local,
+    setup_unittest_data: py.path.local, setup_upload: py.path.local
 ):
     emitter = uploader.EventEmitter()
 

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -1,4 +1,3 @@
-import os
 import typing as T
 from pathlib import Path
 

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -8,7 +8,7 @@ import py.path
 
 import pytest
 
-from mapillary_tools import types, upload_api_v4, uploader, utils, api_v4
+from mapillary_tools import api_v4, types, upload_api_v4, uploader, utils
 
 from ..integration.fixtures import setup_upload, validate_and_extract_zip
 


### PR DESCRIPTION
Upload images file by file concurrently.

Benefits:
* No need to zip images (extra space and IO) and then upload
* Faster upload due to parallel uploading (see below)
* The offset reset issue is mitigated (for imagery uploading only) https://github.com/mapillary/mapillary_tools/issues/569

## Upload speed comparison

Before: single thread uploading a zipfile of 2GB images
```
2.00G/2.00G [02:21<00:00, 15.2MB/s]
```

Now: parallel uploading with 128 workers
```
2.00G/2.00G [00:52<00:00, 41.0MB/s]
```


Now: parallel uploading with 64 workers
```
2.00G/2.00G [00:50<00:00, 42.8MB/s]
```
