### PR TITLE
refactor: improve upload service

### DIFF
--- a/mapillary_tools/upload_api_v4.py
+++ b/mapillary_tools/upload_api_v4.py
@@ -13,10 +13,11 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import override
 
+import tempfile
+
 import requests
 
 from .api_v4 import request_get, request_post, REQUESTS_TIMEOUT
-import tempfile
 
 MAPILLARY_UPLOAD_ENDPOINT = os.getenv(
     "MAPILLARY_UPLOAD_ENDPOINT", "https://rupload.facebook.com/mapillary_public_uploads"

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -528,9 +528,15 @@ class Uploader:
         upload_service: upload_api_v4.UploadService
 
         if self.dry_run:
+            upload_path = os.getenv("MAPILLARY_UPLOAD_ENDPOINT")
             upload_service = upload_api_v4.FakeUploadService(
                 user_access_token=self.user_items["user_upload_token"],
                 session_key=session_key,
+                upload_path=Path(upload_path) if upload_path is not None else None,
+            )
+            LOG.info(
+                "Dry run mode enabled. Data will be uploaded to %s",
+                upload_service.upload_path.joinpath(session_key),
             )
         else:
             upload_service = upload_api_v4.UploadService(

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -14,7 +14,7 @@ import jsonschema
 import py.path
 import pytest
 
-from mapillary_tools import utils
+from mapillary_tools import utils, upload_api_v4
 
 EXECUTABLE = os.getenv(
     "MAPILLARY_TOOLS__TESTS_EXECUTABLE", "python3 -m mapillary_tools.commands"
@@ -58,7 +58,7 @@ def setup_data(tmpdir: py.path.local):
 @pytest.fixture
 def setup_upload(tmpdir: py.path.local):
     upload_dir = tmpdir.mkdir("mapillary_public_uploads")
-    os.environ["MAPILLARY_UPLOAD_PATH"] = str(upload_dir)
+    os.environ["MAPILLARY_UPLOAD_ENDPOINT"] = str(upload_dir)
     os.environ["MAPILLARY_TOOLS__AUTH_VERIFICATION_DISABLED"] = "YES"
     os.environ["MAPILLARY_TOOLS_PROMPT_DISABLED"] = "YES"
     os.environ["MAPILLARY__ENABLE_UPLOAD_HISTORY_FOR_DRY_RUN"] = "YES"
@@ -67,7 +67,7 @@ def setup_upload(tmpdir: py.path.local):
     yield upload_dir
     if tmpdir.check():
         tmpdir.remove(ignore_errors=True)
-    os.environ.pop("MAPILLARY_UPLOAD_PATH", None)
+    os.environ.pop("MAPILLARY_UPLOAD_ENDPOINT", None)
     os.environ.pop("MAPILLARY_UPLOAD_HISTORY_PATH", None)
     os.environ.pop("MAPILLARY_TOOLS__AUTH_VERIFICATION_DISABLED", None)
     os.environ.pop("MAPILLARY_TOOLS_PROMPT_DISABLED", None)
@@ -239,11 +239,11 @@ def load_descs(descs) -> list:
 
 
 def extract_all_uploaded_descs(upload_folder: Path) -> list[list[dict]]:
-    FILE_HANDLE_DIRNAME = "file_handles"
-
     session_by_file_handle: dict[str, str] = {}
-    if upload_folder.joinpath(FILE_HANDLE_DIRNAME).exists():
-        for session_path in upload_folder.joinpath(FILE_HANDLE_DIRNAME).iterdir():
+    if upload_folder.joinpath(upload_api_v4.FakeUploadService.FILE_HANDLE_DIR).exists():
+        for session_path in upload_folder.joinpath(
+            upload_api_v4.FakeUploadService.FILE_HANDLE_DIR
+        ).iterdir():
             file_handle = session_path.read_text()
             session_by_file_handle[file_handle] = session_path.name
 
@@ -267,7 +267,7 @@ def extract_all_uploaded_descs(upload_folder: Path) -> list[list[dict]]:
             sequences.append(validate_and_extract_zip(file))
         elif file.suffix == ".mp4":
             sequences.append(validate_and_extract_camm(file))
-        elif file.name == FILE_HANDLE_DIRNAME:
+        elif file.name == upload_api_v4.FakeUploadService.FILE_HANDLE_DIR:
             # Already processed above
             pass
 

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -14,7 +14,7 @@ import jsonschema
 import py.path
 import pytest
 
-from mapillary_tools import utils, upload_api_v4
+from mapillary_tools import upload_api_v4, utils
 
 EXECUTABLE = os.getenv(
     "MAPILLARY_TOOLS__TESTS_EXECUTABLE", "python3 -m mapillary_tools.commands"

--- a/tests/unit/test_upload_api_v4.py
+++ b/tests/unit/test_upload_api_v4.py
@@ -1,48 +1,50 @@
 import io
+from pathlib import Path
 
 import py
 
 from mapillary_tools import upload_api_v4
 
-from ..integration.fixtures import setup_upload
 
-
-def test_upload(setup_upload: py.path.local):
+def test_upload(tmpdir: py.path.local):
     upload_service = upload_api_v4.FakeUploadService(
         user_access_token="TEST",
         session_key="FOOBAR.txt",
+        upload_path=Path(tmpdir),
     )
     upload_service._transient_error_ratio = 0
     content = b"double_foobar"
     cluster_id = upload_service.upload_byte_stream(io.BytesIO(content), chunk_size=1)
     assert isinstance(cluster_id, str), cluster_id
-    assert (setup_upload.join("FOOBAR.txt").read_binary()) == content
+    assert (tmpdir.join("FOOBAR.txt").read_binary()) == content
 
     # reupload should not affect the file
     upload_service.upload_byte_stream(io.BytesIO(content), chunk_size=1)
-    assert (setup_upload.join("FOOBAR.txt").read_binary()) == content
+    assert (tmpdir.join("FOOBAR.txt").read_binary()) == content
 
 
-def test_upload_big_chunksize(setup_upload: py.path.local):
+def test_upload_big_chunksize(tmpdir: py.path.local):
     upload_service = upload_api_v4.FakeUploadService(
         user_access_token="TEST",
         session_key="FOOBAR.txt",
+        upload_path=Path(tmpdir),
     )
     upload_service._transient_error_ratio = 0
     content = b"double_foobar"
     cluster_id = upload_service.upload_byte_stream(io.BytesIO(content), chunk_size=1000)
     assert isinstance(cluster_id, str), cluster_id
-    assert (setup_upload.join("FOOBAR.txt").read_binary()) == content
+    assert (tmpdir.join("FOOBAR.txt").read_binary()) == content
 
     # reupload should not affect the file
     upload_service.upload_byte_stream(io.BytesIO(content), chunk_size=1000)
-    assert (setup_upload.join("FOOBAR.txt").read_binary()) == content
+    assert (tmpdir.join("FOOBAR.txt").read_binary()) == content
 
 
-def test_upload_chunks(setup_upload: py.path.local):
+def test_upload_chunks(tmpdir: py.path.local):
     upload_service = upload_api_v4.FakeUploadService(
         user_access_token="TEST",
         session_key="FOOBAR2.txt",
+        upload_path=Path(tmpdir),
     )
     upload_service._transient_error_ratio = 0
 
@@ -55,8 +57,8 @@ def test_upload_chunks(setup_upload: py.path.local):
     cluster_id = upload_service.upload_chunks(_gen_chunks())
 
     assert isinstance(cluster_id, str), cluster_id
-    assert (setup_upload.join("FOOBAR2.txt").read_binary()) == b"foobar"
+    assert (tmpdir.join("FOOBAR2.txt").read_binary()) == b"foobar"
 
     # reupload should not affect the file
     upload_service.upload_chunks(_gen_chunks())
-    assert (setup_upload.join("FOOBAR2.txt").read_binary()) == b"foobar"
+    assert (tmpdir.join("FOOBAR2.txt").read_binary()) == b"foobar"

--- a/tests/unit/test_upload_api_v4.py
+++ b/tests/unit/test_upload_api_v4.py
@@ -12,7 +12,7 @@ def test_upload(setup_upload: py.path.local):
         user_access_token="TEST",
         session_key="FOOBAR.txt",
     )
-    upload_service._error_ratio = 0
+    upload_service._transient_error_ratio = 0
     content = b"double_foobar"
     cluster_id = upload_service.upload_byte_stream(io.BytesIO(content), chunk_size=1)
     assert isinstance(cluster_id, str), cluster_id
@@ -28,7 +28,7 @@ def test_upload_big_chunksize(setup_upload: py.path.local):
         user_access_token="TEST",
         session_key="FOOBAR.txt",
     )
-    upload_service._error_ratio = 0
+    upload_service._transient_error_ratio = 0
     content = b"double_foobar"
     cluster_id = upload_service.upload_byte_stream(io.BytesIO(content), chunk_size=1000)
     assert isinstance(cluster_id, str), cluster_id
@@ -44,7 +44,7 @@ def test_upload_chunks(setup_upload: py.path.local):
         user_access_token="TEST",
         session_key="FOOBAR2.txt",
     )
-    upload_service._error_ratio = 0
+    upload_service._transient_error_ratio = 0
 
     def _gen_chunks():
         yield b"foo"

--- a/tests/unit/test_upload_api_v4.py
+++ b/tests/unit/test_upload_api_v4.py
@@ -11,6 +11,7 @@ def test_upload(tmpdir: py.path.local):
         user_access_token="TEST",
         session_key="FOOBAR.txt",
         upload_path=Path(tmpdir),
+        transient_error_ratio=0.02,
     )
     upload_service._transient_error_ratio = 0
     content = b"double_foobar"
@@ -28,6 +29,7 @@ def test_upload_big_chunksize(tmpdir: py.path.local):
         user_access_token="TEST",
         session_key="FOOBAR.txt",
         upload_path=Path(tmpdir),
+        transient_error_ratio=0.02,
     )
     upload_service._transient_error_ratio = 0
     content = b"double_foobar"
@@ -45,6 +47,7 @@ def test_upload_chunks(tmpdir: py.path.local):
         user_access_token="TEST",
         session_key="FOOBAR2.txt",
         upload_path=Path(tmpdir),
+        transient_error_ratio=0.02,
     )
     upload_service._transient_error_ratio = 0
 


### PR DESCRIPTION
Do not write uploaded files into mapillary_public_uploads in current dir. Write them into the tempdir instead (and log the path)