### PR TITLE
upgrade gpxpy to be timezone aware

### DIFF
--- a/mapillary_tools/geotag/geotag_images_from_gpx.py
+++ b/mapillary_tools/geotag/geotag_images_from_gpx.py
@@ -20,12 +20,6 @@ from .geotag_images_from_exif import ImageEXIFExtractor
 LOG = logging.getLogger(__name__)
 
 
-class SyncMode:
-    SYNC = "sync"
-    STRICT_SYNC = "strict_sync"
-    RESET = "reset"
-
-
 class GeotagImagesFromGPX(GeotagImagesFromGeneric):
     def __init__(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ classifiers = [
 ]
 dependencies = [
     "appdirs>=1.4.4,<2.0.0",
-    "construct>=2.10.0,<3.0.0",
-    "exifread==2.3.2",
-    "gpxpy>=1.5.0,<1.6.0",
-    "jsonschema~=4.17.3",
-    "piexif==1.1.3",
+    "construct~=2.10.0",
+    "exifread~=3.0",
+    "gpxpy~=1.6.0",
+    "jsonschema~=4.17.0",
+    "piexif~=1.1",
     "pynmea2>=1.12.0,<2.0.0",
     "requests[socks]>=2.20.0,<3.0.0",
     "tqdm>=4.0,<5.0",

--- a/tests/integration/test_process.py
+++ b/tests/integration/test_process.py
@@ -347,22 +347,22 @@ GPX_CONTENT = """
         <trkseg>
             <trkpt lat="0.02" lon="0.01">
             <ele>1</ele>
-            <time>2018-06-08T20:23:34.805</time>
+            <time>2018-06-08T20:23:34.805Z</time>
             </trkpt>
 
             <trkpt lat="2.02" lon="0.01">
             <ele>2</ele>
-            <time>2018-06-08T20:24:35.809</time>
+            <time>2018-06-08T20:24:35.809Z</time>
             </trkpt>
 
             <trkpt lat="2.02" lon="2.01">
             <ele>4</ele>
-            <time>2018-06-08T20:33:36.813</time>
+            <time>2018-06-08T20:33:36.813Z</time>
             </trkpt>
 
             <trkpt lat="4.02" lon="2.01">
             <ele>9</ele>
-            <time>2018-06-08T20:58:37.812</time>
+            <time>2018-06-08T20:58:37.812Z</time>
             </trkpt>
         </trkseg>
     </trk>


### PR DESCRIPTION
NOTE: it's a breaking change upgrading gpxpy from 1.5 -> 1.6

This pull request focuses on dependency updates, minor code cleanup, and test data consistency improvements. The main highlights are the modernization of dependency version specifications, the removal of an unused class, and updates to test GPX timestamps for stricter ISO 8601 compliance.

Dependency updates and modernization:

* Updated dependency version specifications in `pyproject.toml` to use `~=` (compatible release) and allow newer versions for `construct`, `exifread`, `gpxpy`, `jsonschema`, and `piexif`. This improves compatibility with newer package releases and simplifies future maintenance.

Code cleanup:

* Removed the unused `SyncMode` class from `geotag_images_from_gpx.py`, reducing unnecessary code and potential confusion.

Test data consistency:

* Updated GPX trackpoint timestamps in `test_process.py` to include the trailing `Z`, ensuring timestamps are in strict ISO 8601 format and improving test reliability.