### PR TITLE
feat: upload images with keep-alive

### DIFF
--- a/mapillary_tools/api_v4.py
+++ b/mapillary_tools/api_v4.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import enum
 import logging
 import os
-import ssl
 import typing as T
-from json import dumps
 
 import requests
-from requests.adapters import HTTPAdapter
+
+from . import http
 
 LOG = logging.getLogger(__name__)
 MAPILLARY_CLIENT_TOKEN = os.getenv(
@@ -17,8 +16,7 @@ MAPILLARY_CLIENT_TOKEN = os.getenv(
 MAPILLARY_GRAPH_API_ENDPOINT = os.getenv(
     "MAPILLARY_GRAPH_API_ENDPOINT", "https://graph.mapillary.com"
 )
-REQUESTS_TIMEOUT = 60  # 1 minutes
-USE_SYSTEM_CERTS: bool = False
+REQUESTS_TIMEOUT: float = 60  # 1 minutes
 
 
 class HTTPContentError(Exception):
@@ -39,236 +37,19 @@ class ClusterFileType(enum.Enum):
     MLY_BUNDLE_MANIFEST = "mly_bundle_manifest"
 
 
-class HTTPSystemCertsAdapter(HTTPAdapter):
-    """
-    This adapter uses the system's certificate store instead of the certifi module.
-
-    The implementation is based on the project https://pypi.org/project/pip-system-certs/,
-    which has a system-wide effect.
-    """
-
-    def init_poolmanager(self, *args, **kwargs):
-        ssl_context = ssl.create_default_context()
-        ssl_context.load_default_certs()
-        kwargs["ssl_context"] = ssl_context
-
-        super().init_poolmanager(*args, **kwargs)
-
-    def cert_verify(self, *args, **kwargs):
-        super().cert_verify(*args, **kwargs)
-
-        # By default Python requests uses the ca_certs from the certifi module
-        # But we want to use the certificate store instead.
-        # By clearing the ca_certs variable we force it to fall back on that behaviour (handled in urllib3)
-        if "conn" in kwargs:
-            conn = kwargs["conn"]
-        else:
-            conn = args[0]
-
-        conn.ca_certs = None
+def create_user_session(user_access_token: str) -> requests.Session:
+    session = http.Session()
+    session.headers["Authorization"] = f"OAuth {user_access_token}"
+    return session
 
 
-@T.overload
-def _truncate(s: bytes, limit: int = 256) -> bytes | str: ...
-
-
-@T.overload
-def _truncate(s: str, limit: int = 256) -> str: ...
-
-
-def _truncate(s, limit=256):
-    if limit < len(s):
-        if isinstance(s, bytes):
-            try:
-                s = s.decode("utf-8")
-            except UnicodeDecodeError:
-                pass
-        remaining = len(s) - limit
-        if isinstance(s, bytes):
-            return s[:limit] + f"...({remaining} bytes truncated)".encode("utf-8")
-        else:
-            return str(s[:limit]) + f"...({remaining} chars truncated)"
-    else:
-        return s
-
-
-def _sanitize(headers: T.Mapping[T.Any, T.Any]) -> T.Mapping[T.Any, T.Any]:
-    new_headers = {}
-
-    for k, v in headers.items():
-        if k.lower() in [
-            "authorization",
-            "cookie",
-            "x-fb-access-token",
-            "access-token",
-            "access_token",
-            "password",
-            "user_upload_token",
-        ]:
-            new_headers[k] = "[REDACTED]"
-        else:
-            if isinstance(v, (str, bytes)):
-                new_headers[k] = T.cast(T.Any, _truncate(v))
-            else:
-                new_headers[k] = v
-
-    return new_headers
-
-
-def _log_debug_request(
-    method: str,
-    url: str,
-    json: dict | None = None,
-    params: dict | None = None,
-    headers: dict | None = None,
-    timeout: T.Any = None,
-):
-    if logging.getLogger().getEffectiveLevel() <= logging.DEBUG:
-        return
-
-    msg = f"HTTP {method} {url}"
-
-    if USE_SYSTEM_CERTS:
-        msg += " (w/sys_certs)"
-
-    if json:
-        t = _truncate(dumps(_sanitize(json)))
-        msg += f" JSON={t}"
-
-    if params:
-        msg += f" PARAMS={_sanitize(params)}"
-
-    if headers:
-        msg += f" HEADERS={_sanitize(headers)}"
-
-    if timeout is not None:
-        msg += f" TIMEOUT={timeout}"
-
-    msg = msg.replace("\n", "\\n")
-
-    LOG.debug(msg)
-
-
-def _log_debug_response(resp: requests.Response):
-    if logging.getLogger().getEffectiveLevel() <= logging.DEBUG:
-        return
-
-    elapsed = resp.elapsed.total_seconds() * 1000  # Convert to milliseconds
-    msg = f"HTTP {resp.status_code} {resp.reason} ({elapsed:.0f} ms): {str(_truncate_response_content(resp))}"
-
-    LOG.debug(msg)
-
-
-def _truncate_response_content(resp: requests.Response) -> str | bytes:
-    try:
-        json_data = resp.json()
-    except requests.JSONDecodeError:
-        if resp.content is not None:
-            data = _truncate(resp.content)
-        else:
-            data = ""
-    else:
-        if isinstance(json_data, dict):
-            data = _truncate(dumps(_sanitize(json_data)))
-        else:
-            data = _truncate(str(json_data))
-
-    if isinstance(data, bytes):
-        return data.replace(b"\n", b"\\n")
-
-    elif isinstance(data, str):
-        return data.replace("\n", "\\n")
-
-    return data
-
-
-def readable_http_error(ex: requests.HTTPError) -> str:
-    return readable_http_response(ex.response)
-
-
-def readable_http_response(resp: requests.Response) -> str:
-    return f"{resp.request.method} {resp.url} => {resp.status_code} {resp.reason}: {str(_truncate_response_content(resp))}"
-
-
-def request_post(
-    url: str,
-    data: T.Any | None = None,
-    json: dict | None = None,
-    disable_debug=False,
-    **kwargs,
-) -> requests.Response:
-    global USE_SYSTEM_CERTS
-
-    if not disable_debug:
-        _log_debug_request(
-            "POST",
-            url,
-            json=json,
-            params=kwargs.get("params"),
-            headers=kwargs.get("headers"),
-            timeout=kwargs.get("timeout"),
-        )
-
-    if USE_SYSTEM_CERTS:
-        with requests.Session() as session:
-            session.mount("https://", HTTPSystemCertsAdapter())
-            resp = session.post(url, data=data, json=json, **kwargs)
-
-    else:
-        try:
-            resp = requests.post(url, data=data, json=json, **kwargs)
-        except requests.exceptions.SSLError as ex:
-            if "SSLCertVerificationError" not in str(ex):
-                raise ex
-            USE_SYSTEM_CERTS = True
-            # HTTPSConnectionPool(host='graph.mapillary.com', port=443): Max retries exceeded with url: /login (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1018)')))
-            LOG.warning(
-                "SSL error occurred, falling back to system SSL certificates: %s", ex
-            )
-            return request_post(url, data=data, json=json, **kwargs)
-
-    if not disable_debug:
-        _log_debug_response(resp)
-
-    return resp
-
-
-def request_get(
-    url: str, params: dict | None = None, disable_debug=False, **kwargs
-) -> requests.Response:
-    global USE_SYSTEM_CERTS
-
-    if not disable_debug:
-        _log_debug_request(
-            "GET",
-            url,
-            params=kwargs.get("params"),
-            headers=kwargs.get("headers"),
-            # Do not log timeout here as it's always set to REQUESTS_TIMEOUT
-            timeout=None,
-        )
-
-    if USE_SYSTEM_CERTS:
-        with requests.Session() as session:
-            session.mount("https://", HTTPSystemCertsAdapter())
-            resp = session.get(url, params=params, **kwargs)
-    else:
-        try:
-            resp = requests.get(url, params=params, **kwargs)
-        except requests.exceptions.SSLError as ex:
-            if "SSLCertVerificationError" not in str(ex):
-                raise ex
-            USE_SYSTEM_CERTS = True
-            # HTTPSConnectionPool(host='graph.mapillary.com', port=443): Max retries exceeded with url: /login (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1018)')))
-            LOG.warning(
-                "SSL error occurred, falling back to system SSL certificates: %s", ex
-            )
-            resp = request_get(url, params=params, **kwargs)
-
-    if not disable_debug:
-        _log_debug_response(resp)
-
-    return resp
+def create_client_session(disable_logging: bool = False) -> requests.Session:
+    session = http.Session()
+    session.headers["Authorization"] = f"OAuth {MAPILLARY_CLIENT_TOKEN}"
+    if disable_logging:
+        session.disable_logging_request = True
+        session.disable_logging_response = True
+    return session
 
 
 def is_auth_error(resp: requests.Response) -> bool:
@@ -309,54 +90,42 @@ def extract_auth_error_message(resp: requests.Response) -> str:
     return resp.text
 
 
-def get_upload_token(email: str, password: str) -> requests.Response:
-    resp = request_post(
-        f"{MAPILLARY_GRAPH_API_ENDPOINT}/login",
-        headers={"Authorization": f"OAuth {MAPILLARY_CLIENT_TOKEN}"},
-        json={"email": email, "password": password, "locale": "en_US"},
-        timeout=REQUESTS_TIMEOUT,
-    )
+def get_upload_token(
+    client_session: requests.Session, email: str, password: str
+) -> requests.Response:
+    url = f"{MAPILLARY_GRAPH_API_ENDPOINT}/login"
+    json_data = {"email": email, "password": password, "locale": "en_US"}
+
+    resp = client_session.post(url, json=json_data, timeout=REQUESTS_TIMEOUT)
     resp.raise_for_status()
+
     return resp
 
 
 def fetch_organization(
-    user_access_token: str, organization_id: int | str
+    user_session: requests.Session, organization_id: int | str
 ) -> requests.Response:
-    resp = request_get(
-        f"{MAPILLARY_GRAPH_API_ENDPOINT}/{organization_id}",
-        params={
-            "fields": ",".join(["slug", "description", "name"]),
-        },
-        headers={
-            "Authorization": f"OAuth {user_access_token}",
-        },
-        timeout=REQUESTS_TIMEOUT,
-    )
+    url = f"{MAPILLARY_GRAPH_API_ENDPOINT}/{organization_id}"
+    params = {"fields": ",".join(["slug", "description", "name"])}
+
+    resp = user_session.get(url, params=params, timeout=REQUESTS_TIMEOUT)
     resp.raise_for_status()
+
     return resp
 
 
 def fetch_user_or_me(
-    user_access_token: str, user_id: int | str | None = None
+    user_session: requests.Session, user_id: int | str | None = None
 ) -> requests.Response:
     if user_id is None:
         url = f"{MAPILLARY_GRAPH_API_ENDPOINT}/me"
     else:
         url = f"{MAPILLARY_GRAPH_API_ENDPOINT}/{user_id}"
+    params = {"fields": ",".join(["id", "username"])}
 
-    resp = request_get(
-        url,
-        params={
-            "fields": ",".join(["id", "username"]),
-        },
-        headers={
-            "Authorization": f"OAuth {user_access_token}",
-        },
-        timeout=REQUESTS_TIMEOUT,
-    )
-
+    resp = user_session.get(url, params=params, timeout=REQUESTS_TIMEOUT)
     resp.raise_for_status()
+
     return resp
 
 
@@ -365,42 +134,33 @@ ActionType = T.Literal[
 ]
 
 
-def log_event(action_type: ActionType, properties: dict) -> requests.Response:
-    resp = request_post(
-        f"{MAPILLARY_GRAPH_API_ENDPOINT}/logging",
-        json={"action_type": action_type, "properties": properties},
-        headers={
-            "Authorization": f"OAuth {MAPILLARY_CLIENT_TOKEN}",
-        },
-        timeout=REQUESTS_TIMEOUT,
-        disable_debug=True,
-    )
+def log_event(
+    client_session: requests.Session, action_type: ActionType, properties: dict
+) -> requests.Response:
+    url = f"{MAPILLARY_GRAPH_API_ENDPOINT}/logging"
+    json_data = {"action_type": action_type, "properties": properties}
+
+    resp = client_session.post(url, json=json_data, timeout=REQUESTS_TIMEOUT)
     resp.raise_for_status()
+
     return resp
 
 
 def finish_upload(
-    user_access_token: str,
+    user_session: requests.Session,
     file_handle: str,
     cluster_filetype: ClusterFileType,
     organization_id: int | str | None = None,
 ) -> requests.Response:
-    data: dict[str, str | int] = {
+    url = f"{MAPILLARY_GRAPH_API_ENDPOINT}/finish_upload"
+    json_data: dict[str, str | int] = {
         "file_handle": file_handle,
         "file_type": cluster_filetype.value,
     }
     if organization_id is not None:
-        data["organization_id"] = organization_id
+        json_data["organization_id"] = organization_id
 
-    resp = request_post(
-        f"{MAPILLARY_GRAPH_API_ENDPOINT}/finish_upload",
-        headers={
-            "Authorization": f"OAuth {user_access_token}",
-        },
-        json=data,
-        timeout=REQUESTS_TIMEOUT,
-    )
-
+    resp = user_session.post(url, json=json_data, timeout=REQUESTS_TIMEOUT)
     resp.raise_for_status()
 
     return resp

--- a/mapillary_tools/commands/upload.py
+++ b/mapillary_tools/commands/upload.py
@@ -24,6 +24,13 @@ class Command:
             required=False,
         )
         group.add_argument(
+            "--num_upload_workers",
+            help="Number of concurrent upload workers for uploading images. [default: %(default)s]",
+            default=constants.MAX_IMAGE_UPLOAD_WORKERS,
+            type=int,
+            required=False,
+        )
+        group.add_argument(
             "--reupload",
             help="Re-upload data that has already been uploaded.",
             action="store_true",

--- a/mapillary_tools/constants.py
+++ b/mapillary_tools/constants.py
@@ -154,16 +154,18 @@ UPLOAD_CACHE_DIR: str = os.getenv(
 # The minimal upload speed is used to calculate the read timeout to avoid upload hanging:
 # timeout = upload_size / MIN_UPLOAD_SPEED
 MIN_UPLOAD_SPEED: int | None = _parse_filesize(
-    os.getenv(_ENV_PREFIX + "MIN_UPLOAD_SPEED", "50K")  # 50 KiB/s
+    os.getenv(_ENV_PREFIX + "MIN_UPLOAD_SPEED", "50K")  # 50 Kb/s
 )
+# Maximum number of parallel workers for uploading images within a single sequence.
+# NOTE: Sequences themselves are uploaded sequentially, not in parallel.
 MAX_IMAGE_UPLOAD_WORKERS: int = int(
-    os.getenv(_ENV_PREFIX + "MAX_IMAGE_UPLOAD_WORKERS", 64)
+    os.getenv(_ENV_PREFIX + "MAX_IMAGE_UPLOAD_WORKERS", 4)
 )
 # The chunk size in MB (see chunked transfer encoding https://en.wikipedia.org/wiki/Chunked_transfer_encoding)
 # for uploading data to MLY upload service.
 # Changing this size does not change the number of requests nor affect upload performance,
 # but it affects the responsiveness of the upload progress bar
-UPLOAD_CHUNK_SIZE_MB: float = float(os.getenv(_ENV_PREFIX + "UPLOAD_CHUNK_SIZE_MB", 1))
+UPLOAD_CHUNK_SIZE_MB: float = float(os.getenv(_ENV_PREFIX + "UPLOAD_CHUNK_SIZE_MB", 2))
 MAX_UPLOAD_RETRIES: int = int(os.getenv(_ENV_PREFIX + "MAX_UPLOAD_RETRIES", 200))
 MAPILLARY__ENABLE_UPLOAD_HISTORY_FOR_DRY_RUN: bool = _yes_or_no(
     os.getenv("MAPILLARY__ENABLE_UPLOAD_HISTORY_FOR_DRY_RUN", "NO")

--- a/mapillary_tools/http.py
+++ b/mapillary_tools/http.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import logging
+
+import ssl
+import typing as T
+from json import dumps
+
+import requests
+from requests.adapters import HTTPAdapter
+
+
+LOG = logging.getLogger(__name__)
+
+
+class HTTPSystemCertsAdapter(HTTPAdapter):
+    """
+    This adapter uses the system's certificate store instead of the certifi module.
+
+    The implementation is based on the project https://pypi.org/project/pip-system-certs/,
+    which has a system-wide effect.
+    """
+
+    def init_poolmanager(self, *args, **kwargs):
+        ssl_context = ssl.create_default_context()
+        ssl_context.load_default_certs()
+        kwargs["ssl_context"] = ssl_context
+
+        super().init_poolmanager(*args, **kwargs)
+
+    def cert_verify(self, *args, **kwargs):
+        super().cert_verify(*args, **kwargs)
+
+        # By default Python requests uses the ca_certs from the certifi module
+        # But we want to use the certificate store instead.
+        # By clearing the ca_certs variable we force it to fall back on that behaviour (handled in urllib3)
+        if "conn" in kwargs:
+            conn = kwargs["conn"]
+        else:
+            conn = args[0]
+
+        conn.ca_certs = None
+
+
+class Session(requests.Session):
+    # NOTE: This is a global flag that affects all Session instances
+    USE_SYSTEM_CERTS: T.ClassVar[bool] = False
+    # Instance variables
+    disable_logging_request: bool = False
+    disable_logging_response: bool = False
+    # Avoid mounting twice
+    _mounted: bool = False
+
+    @T.override
+    def request(self, method: str | bytes, url: str | bytes, *args, **kwargs):
+        self._log_debug_request(method, url, *args, **kwargs)
+
+        if Session.USE_SYSTEM_CERTS:
+            if not self._mounted:
+                self.mount("https://", HTTPSystemCertsAdapter())
+                self._mounted = True
+            resp = super().request(method, url, *args, **kwargs)
+        else:
+            try:
+                resp = super().request(method, url, *args, **kwargs)
+            except requests.exceptions.SSLError as ex:
+                if "SSLCertVerificationError" not in str(ex):
+                    raise ex
+                Session.USE_SYSTEM_CERTS = True
+                # HTTPSConnectionPool(host='graph.mapillary.com', port=443): Max retries exceeded with url: /login (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1018)')))
+                LOG.warning(
+                    "SSL error occurred, falling back to system SSL certificates: %s",
+                    ex,
+                )
+                return self.request(method, url, *args, **kwargs)
+
+        self._log_debug_response(resp)
+
+        return resp
+
+    def _log_debug_request(self, method: str | bytes, url: str | bytes, **kwargs):
+        if self.disable_logging_request:
+            return
+
+        if logging.getLogger().getEffectiveLevel() <= logging.DEBUG:
+            return
+
+        if isinstance(method, str) and isinstance(url, str):
+            msg = f"HTTP {method} {url}"
+        else:
+            msg = f"HTTP {method!r} {url!r}"
+
+        if Session.USE_SYSTEM_CERTS:
+            msg += " (w/sys_certs)"
+
+        json = kwargs.get("json")
+        if json is not None:
+            t = _truncate(dumps(_sanitize(json)))
+            msg += f" JSON={t}"
+
+        params = kwargs.get("params")
+        if params is not None:
+            msg += f" PARAMS={_sanitize(params)}"
+
+        headers = kwargs.get("headers")
+        if headers is not None:
+            msg += f" HEADERS={_sanitize(headers)}"
+
+        timeout = kwargs.get("timeout")
+        if timeout is not None:
+            msg += f" TIMEOUT={timeout}"
+
+        msg = msg.replace("\n", "\\n")
+
+        LOG.debug(msg)
+
+    def _log_debug_response(self, resp: requests.Response):
+        if self.disable_logging_response:
+            return
+
+        if logging.getLogger().getEffectiveLevel() <= logging.DEBUG:
+            return
+
+        elapsed = resp.elapsed.total_seconds() * 1000  # Convert to milliseconds
+        msg = f"HTTP {resp.status_code} {resp.reason} ({elapsed:.0f} ms): {str(_truncate_response_content(resp))}"
+
+        LOG.debug(msg)
+
+
+def readable_http_error(ex: requests.HTTPError) -> str:
+    return readable_http_response(ex.response)
+
+
+def readable_http_response(resp: requests.Response) -> str:
+    return f"{resp.request.method} {resp.url} => {resp.status_code} {resp.reason}: {str(_truncate_response_content(resp))}"
+
+
+@T.overload
+def _truncate(s: bytes, limit: int = 256) -> bytes | str: ...
+
+
+@T.overload
+def _truncate(s: str, limit: int = 256) -> str: ...
+
+
+def _truncate(s, limit=256):
+    if limit < len(s):
+        if isinstance(s, bytes):
+            try:
+                s = s.decode("utf-8")
+            except UnicodeDecodeError:
+                pass
+        remaining = len(s) - limit
+        if isinstance(s, bytes):
+            return s[:limit] + f"...({remaining} bytes truncated)".encode("utf-8")
+        else:
+            return str(s[:limit]) + f"...({remaining} chars truncated)"
+    else:
+        return s
+
+
+def _sanitize(headers: T.Mapping[T.Any, T.Any]) -> T.Mapping[T.Any, T.Any]:
+    new_headers = {}
+
+    for k, v in headers.items():
+        if k.lower() in [
+            "authorization",
+            "cookie",
+            "x-fb-access-token",
+            "access-token",
+            "access_token",
+            "password",
+            "user_upload_token",
+        ]:
+            new_headers[k] = "[REDACTED]"
+        else:
+            if isinstance(v, (str, bytes)):
+                new_headers[k] = T.cast(T.Any, _truncate(v))
+            else:
+                new_headers[k] = v
+
+    return new_headers
+
+
+def _truncate_response_content(resp: requests.Response) -> str | bytes:
+    try:
+        json_data = resp.json()
+    except requests.JSONDecodeError:
+        if resp.content is not None:
+            data = _truncate(resp.content)
+        else:
+            data = ""
+    else:
+        if isinstance(json_data, dict):
+            data = _truncate(dumps(_sanitize(json_data)))
+        else:
+            data = _truncate(str(json_data))
+
+    if isinstance(data, bytes):
+        return data.replace(b"\n", b"\\n")
+
+    elif isinstance(data, str):
+        return data.replace("\n", "\\n")
+
+    return data

--- a/mapillary_tools/http.py
+++ b/mapillary_tools/http.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 import logging
 
 import ssl
+import sys
 import typing as T
 from json import dumps
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -51,7 +57,7 @@ class Session(requests.Session):
     # Avoid mounting twice
     _mounted: bool = False
 
-    @T.override
+    @override
     def request(self, method: str | bytes, url: str | bytes, *args, **kwargs):
         self._log_debug_request(method, url, *args, **kwargs)
 

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -493,7 +493,7 @@ def _show_upload_summary(stats: T.Sequence[_APIStats], errors: T.Sequence[Except
         LOG.info(
             f"{humanize.naturalsize(summary['uploaded_size'] * 1024 * 1024)} uploaded"
         )
-        LOG.info(f"{summary['time']} upload time")
+        LOG.info(f"{summary['time']:.3f} seconds upload time")
     else:
         LOG.info("Nothing uploaded. Bye.")
 

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -562,9 +562,10 @@ def _gen_upload_everything(
         (m for m in metadatas if isinstance(m, types.ImageMetadata)),
         utils.find_images(import_paths, skip_subfolders=skip_subfolders),
     )
-    yield from uploader.ImageSequenceUploader.upload_images(
-        mly_uploader, image_metadatas
+    image_uploader = uploader.ImageSequenceUploader(
+        mly_uploader.upload_options, emitter=mly_uploader.emitter
     )
+    yield from image_uploader.upload_images(image_metadatas)
 
     # Upload videos
     video_metadatas = _find_metadata_with_filename_existed_in(

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -410,8 +410,8 @@ def _setup_api_stats(emitter: uploader.EventEmitter):
             payload["offset"], payload.get("upload_first_offset", payload["offset"])
         )
 
-    @emitter.on("upload_interrupted")
-    def collect_interrupted(payload: _APIStats):
+    @emitter.on("upload_retrying")
+    def collect_retrying(payload: _APIStats):
         # could be None if it failed to fetch offset
         restart_time = payload.get("upload_last_restart_time")
         if restart_time is not None:

--- a/mapillary_tools/upload.py
+++ b/mapillary_tools/upload.py
@@ -207,31 +207,25 @@ def _setup_history(
         record = history.read_history_record(md5sum)
 
         if record is not None:
-            sequence_uuid = payload.get("sequence_uuid")
             history_desc_path = history.history_desc_path(md5sum)
             uploaded_at = record.get("summary", {}).get("upload_end_time", None)
 
-            if sequence_uuid is None:
-                basename = os.path.basename(payload.get("import_path", ""))
-                name = f"file {basename}"
-
-            else:
-                name = f"sequence {sequence_uuid}"
+            upload_name = uploader.Uploader._upload_name(payload)
 
             if reupload:
                 if uploaded_at is not None:
                     LOG.info(
-                        f"Reuploading {name}: previously uploaded {humanize.naturaldelta(time.time() - uploaded_at)} ago ({time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(uploaded_at))})"
+                        f"Reuploading {upload_name}, despite being uploaded {humanize.naturaldelta(time.time() - uploaded_at)} ago ({time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(uploaded_at))})"
                     )
                 else:
                     LOG.info(
-                        f"Reuploading {name}: already uploaded, see {history_desc_path}"
+                        f"Reuploading {upload_name}, despite already being uploaded (see {history_desc_path})"
                     )
             else:
                 if uploaded_at is not None:
-                    msg = f"Skipping {name}: previously uploaded {humanize.naturaldelta(time.time() - uploaded_at)} ago ({time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(uploaded_at))})"
+                    msg = f"Skipping {upload_name}, already uploaded {humanize.naturaldelta(time.time() - uploaded_at)} ago ({time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(uploaded_at))})"
                 else:
-                    msg = f"Skipping {name}: already uploaded, see {history_desc_path}"
+                    msg = f"Skipping {upload_name}, already uploaded (see {history_desc_path})"
                 raise UploadedAlready(msg)
 
     @emitter.on("upload_finished")

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -785,8 +785,8 @@ class Uploader:
         if self.upload_options.dry_run:
             upload_path = os.getenv("MAPILLARY_UPLOAD_ENDPOINT")
             upload_service = upload_api_v4.FakeUploadService(
-                user_access_token=self.upload_options.user_items["user_upload_token"],
-                session_key=session_key,
+                user_session,
+                session_key,
                 upload_path=Path(upload_path) if upload_path is not None else None,
             )
             LOG.info(
@@ -794,9 +794,7 @@ class Uploader:
                 upload_service.upload_path.joinpath(session_key),
             )
         else:
-            upload_service = upload_api_v4.UploadService(
-                user_session, session_key=session_key
-            )
+            upload_service = upload_api_v4.UploadService(user_session, session_key)
 
         return upload_service
 
@@ -852,7 +850,10 @@ class Uploader:
         ) as user_session:
             upload_service = self._create_upload_service(user_session, session_key)
 
-            begin_offset = upload_service.fetch_offset()
+            if _is_uuid(session_key):
+                begin_offset = 0
+            else:
+                begin_offset = upload_service.fetch_offset()
 
             progress["begin_offset"] = begin_offset
             progress["offset"] = begin_offset

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -1042,10 +1042,7 @@ class Uploader:
             entity_size = fp.tell()
             progress["entity_size"] = entity_size
 
-        if _is_uuid(session_key):
-            begin_offset = 0
-        else:
-            begin_offset = upload_service.fetch_offset()
+        begin_offset = upload_service.fetch_offset()
 
         progress["begin_offset"] = begin_offset
         progress["offset"] = begin_offset

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -659,7 +659,8 @@ class ImageSequenceUploader:
 
         # All tasks should be done here, so below is more like assertion
         image_queue.join()
-        image_queue.shutdown()
+        if sys.version_info >= (3, 13):
+            image_queue.shutdown()
 
         file_handles: list[str] = []
 

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -730,7 +730,7 @@ class SingleImageUploader:
         self.upload_options = upload_options
         self.user_session = user_session
         self.cache = self._maybe_create_persistent_cache_instance(
-            self.upload_options.user_items
+            self.upload_options.user_items, upload_options
         )
 
     def upload(self, image_metadata: types.ImageMetadata) -> str:
@@ -773,12 +773,16 @@ class SingleImageUploader:
 
     @classmethod
     def _maybe_create_persistent_cache_instance(
-        cls, user_items: config.UserItem
+        cls, user_items: config.UserItem, upload_options: UploadOptions
     ) -> history.PersistentCache | None:
         if not constants.UPLOAD_CACHE_DIR:
             LOG.debug(
                 "Upload cache directory is set empty, skipping caching upload file handles"
             )
+            return None
+
+        if upload_options.dry_run:
+            LOG.debug("Dry-run mode enabled, skipping caching upload file handles")
             return None
 
         cache_path_dir = (

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -996,8 +996,10 @@ class Uploader:
     def _upload_name(cls, progress: UploaderProgress):
         # Strictly speaking these sequence properties should not be exposed in this context
         # TODO: Maybe move these logging statements to event handlers
-        sequence_uuid: str | None = T.cast(str | None, progress.get("sequence_uuid"))
-        import_path = T.cast(str | None, progress.get("import_path"))
+        sequence_uuid: str | None = T.cast(
+            T.Union[str, None], progress.get("sequence_uuid")
+        )
+        import_path = T.cast(T.Union[str, None], progress.get("import_path"))
         if sequence_uuid is not None:
             if import_path is None:
                 name: str = f"sequence_{sequence_uuid}"

--- a/tests/unit/test_upload_api_v4.py
+++ b/tests/unit/test_upload_api_v4.py
@@ -8,7 +8,7 @@ from mapillary_tools import upload_api_v4
 
 def test_upload(tmpdir: py.path.local):
     upload_service = upload_api_v4.FakeUploadService(
-        user_access_token="TEST",
+        user_session=None,
         session_key="FOOBAR.txt",
         upload_path=Path(tmpdir),
         transient_error_ratio=0.02,
@@ -26,7 +26,7 @@ def test_upload(tmpdir: py.path.local):
 
 def test_upload_big_chunksize(tmpdir: py.path.local):
     upload_service = upload_api_v4.FakeUploadService(
-        user_access_token="TEST",
+        user_session=None,
         session_key="FOOBAR.txt",
         upload_path=Path(tmpdir),
         transient_error_ratio=0.02,
@@ -44,7 +44,7 @@ def test_upload_big_chunksize(tmpdir: py.path.local):
 
 def test_upload_chunks(tmpdir: py.path.local):
     upload_service = upload_api_v4.FakeUploadService(
-        user_access_token="TEST",
+        user_session=None,
         session_key="FOOBAR2.txt",
         upload_path=Path(tmpdir),
         transient_error_ratio=0.02,


### PR DESCRIPTION
This pull request refactors the API v4 authentication and HTTP request logic to streamline session management, improve code clarity, and make upload worker configuration more flexible. The main changes include replacing custom HTTP request handling with a shared `http.Session`, updating authentication flows to use session objects, and introducing a configurable number of upload workers.

**API and HTTP session refactoring:**

* Removed custom HTTP request functions and SSL adapter logic from `api_v4.py`, replacing them with new `create_user_session` and `create_client_session` helpers that return pre-configured `http.Session` objects for authenticated requests. All API methods now accept a session object instead of raw tokens. [[1]](diffhunk://#diff-31912c9803790ab2628fcd3fa9fba2976ca2e501f9c561811bc7c2ae2b0167daL6-R10) [[2]](diffhunk://#diff-31912c9803790ab2628fcd3fa9fba2976ca2e501f9c561811bc7c2ae2b0167daL42-R52) [[3]](diffhunk://#diff-31912c9803790ab2628fcd3fa9fba2976ca2e501f9c561811bc7c2ae2b0167daL312-R128) [[4]](diffhunk://#diff-31912c9803790ab2628fcd3fa9fba2976ca2e501f9c561811bc7c2ae2b0167daL368-R163)
* Moved request/response logging and header sanitization utilities to the new `http` module, updating all usages accordingly. [[1]](diffhunk://#diff-2407eca920850f3967f1f4f508fb7dbc07857af82e5db3a38dde7174083baef6L13-R13) [[2]](diffhunk://#diff-2407eca920850f3967f1f4f508fb7dbc07857af82e5db3a38dde7174083baef6L80-R84)

**Authentication flow updates:**

* Updated authentication and user verification logic in `authenticate.py` to use the new session-based API, ensuring all requests are made through properly configured session objects. [[1]](diffhunk://#diff-2407eca920850f3967f1f4f508fb7dbc07857af82e5db3a38dde7174083baef6L137-R138) [[2]](diffhunk://#diff-2407eca920850f3967f1f4f508fb7dbc07857af82e5db3a38dde7174083baef6R175-R177) [[3]](diffhunk://#diff-2407eca920850f3967f1f4f508fb7dbc07857af82e5db3a38dde7174083baef6R277-R279)

**Upload worker configuration:**

* Added a new `--num_upload_workers` CLI argument to allow users to specify the number of concurrent upload workers, with a new default value.
* Changed the default and maximum number of image upload workers from 64 to 4, and increased the upload chunk size from 1MB to 2MB for improved responsiveness.

These changes improve maintainability, security, and configurability of the upload and authentication processes.