### PR TITLE
Calculate video filesize when using gpx extractor

### DIFF
--- a/mapillary_tools/geotag/video_extractors/gpx.py
+++ b/mapillary_tools/geotag/video_extractors/gpx.py
@@ -12,7 +12,7 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import override
 
-from ... import exceptions, geo, telemetry, types
+from ... import exceptions, geo, telemetry, types, utils
 from ..utils import parse_gpx
 from .base import BaseVideoExtractor
 from .native import NativeVideoExtractor
@@ -59,6 +59,7 @@ class GPXVideoExtractor(BaseVideoExtractor):
             self._rebase_times(gpx_points)
             return types.VideoMetadata(
                 filename=self.video_path,
+                filesize=utils.get_file_size(self.video_path),
                 filetype=types.FileType.VIDEO,
                 points=gpx_points,
             )

--- a/tests/integration/test_process.py
+++ b/tests/integration/test_process.py
@@ -602,6 +602,7 @@ def test_process_video_geotag_source_with_gpx_specified(setup_data: py.path.loca
 
     assert len(descs) == 1
     assert len(descs[0]["MAPGPSTrack"]) > 0
+    assert descs[0]["filesize"] == 2848208
 
 
 def test_process_video_geotag_source_gpx_not_found(setup_data: py.path.local):


### PR DESCRIPTION
This PR adds the missing filesize calculation to the GPX extractor so all videos processed by MT have a filesize.