### PR TITLE
fix: race condition in image uploader

### DIFF
--- a/mapillary_tools/history.py
+++ b/mapillary_tools/history.py
@@ -162,6 +162,11 @@ class PersistentCache:
 
         return expired_keys
 
+    def keys(self):
+        with self._lock:
+            with dbm.open(self._file, flag="c") as db:
+                return db.keys()
+
     def _is_expired(self, payload: JSONDict) -> bool:
         expires_at = payload.get("expires_at")
         if isinstance(expires_at, (int, float)):

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -537,10 +537,13 @@ class ImageSequenceUploader:
     def __init__(self, upload_options: UploadOptions, emitter: EventEmitter):
         self.upload_options = upload_options
         self.emitter = emitter
-        self.cache = _maybe_create_persistent_cache_instance(upload_options)
         # Create a single shared SingleImageUploader instance that will be used across all uploads
+        cache = _maybe_create_persistent_cache_instance(self.upload_options)
+        self.cache: history.PersistentCache | None = (
+            cache  # Expose cache instance for testing and external access
+        )
         self.single_image_uploader = SingleImageUploader(
-            upload_options, cache=self.cache
+            self.upload_options, cache=cache
         )
 
     def upload_images(

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -475,7 +475,7 @@ class ZipUploader:
                 # Arcname should be unique, the name does not matter
                 arcname = f"{idx}.jpg"
                 zipinfo = zipfile.ZipInfo(arcname, date_time=(1980, 1, 1, 0, 0, 0))
-                zipf.writestr(zipinfo, SingleImageUploader.dump_image_bytes(metadata))
+                zipf.writestr(zipinfo, CachedImageUploader.dump_image_bytes(metadata))
             assert len(sequence) == len(set(zipf.namelist()))
             zipf.comment = json.dumps(
                 {"sequence_md5sum": sequence_md5sum},
@@ -545,7 +545,7 @@ class ImageSequenceUploader:
         cache = _maybe_create_persistent_cache_instance(self.upload_options)
         if cache:
             cache.clear_expired()
-        self.single_image_uploader = SingleImageUploader(
+        self.cached_image_uploader = CachedImageUploader(
             self.upload_options, cache=cache
         )
 
@@ -717,7 +717,7 @@ class ImageSequenceUploader:
                 }
 
                 # image_progress will be updated during uploading
-                file_handle = self.single_image_uploader.upload(
+                file_handle = self.cached_image_uploader.upload(
                     user_session, image_metadata, image_progress
                 )
 
@@ -738,7 +738,7 @@ class ImageSequenceUploader:
         return indexed_file_handles
 
 
-class SingleImageUploader:
+class CachedImageUploader:
     def __init__(
         self,
         upload_options: UploadOptions,

--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -57,6 +57,8 @@ class UploadOptions:
     user_items: config.UserItem
     chunk_size: int = int(constants.UPLOAD_CHUNK_SIZE_MB * 1024 * 1024)
     num_upload_workers: int = constants.MAX_IMAGE_UPLOAD_WORKERS
+    # When set, upload cache will be read/write there
+    # This option is exposed for testing purpose. In PROD, the path is calculated based on envvar and user_items
     upload_cache_path: Path | None = None
     dry_run: bool = False
     nofinish: bool = False
@@ -743,14 +745,9 @@ class SingleImageUploader:
         cache: history.PersistentCache | None = None,
     ):
         self.upload_options = upload_options
-        # Accept cache instance from caller, or create one if none provided (for backward compatibility)
-        if cache is not None:
-            self.cache: history.PersistentCache | None = cache
-        else:
-            # Backward compatibility: create cache if not provided
-            self.cache = _maybe_create_persistent_cache_instance(upload_options)
-            if self.cache:
-                self.cache.clear_expired()
+        self.cache = cache
+        if self.cache:
+            self.cache.clear_expired()
 
     # Thread-safe
     def upload(

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -321,12 +321,12 @@ class TestImageSequenceUploader:
         sequence_uploader.upload_options = dataclasses.replace(
             upload_options_with_cache, dry_run=True
         )
-        sequence_uploader.single_image_uploader.upload_options = dataclasses.replace(
+        sequence_uploader.cached_image_uploader.upload_options = dataclasses.replace(
             upload_options_with_cache, dry_run=True
         )
 
         # Verify cache is available and shared
-        assert sequence_uploader.single_image_uploader.cache is not None, (
+        assert sequence_uploader.cached_image_uploader.cache is not None, (
             "SingleImageUploader should share the same cache instance"
         )
 
@@ -378,7 +378,7 @@ class TestImageSequenceUploader:
             sequence_uploader = uploader.ImageSequenceUploader(upload_options, emitter)
 
             # Verify cache is disabled for both instances
-            assert sequence_uploader.single_image_uploader.cache is None, (
+            assert sequence_uploader.cached_image_uploader.cache is None, (
                 "Should have cache disabled"
             )
 
@@ -421,7 +421,7 @@ class TestImageSequenceUploader:
 
             # Should safely return None without error
             retrieved_value = (
-                sequence_uploader.single_image_uploader._get_cached_file_handle(
+                sequence_uploader.cached_image_uploader._get_cached_file_handle(
                     test_key
                 )
             )
@@ -430,13 +430,13 @@ class TestImageSequenceUploader:
             )
 
             # Should safely do nothing without error
-            sequence_uploader.single_image_uploader._set_file_handle_cache(
+            sequence_uploader.cached_image_uploader._set_file_handle_cache(
                 test_key, test_value
             )
 
             # Verify the value is still None after attempted set
             retrieved_value_after_set = (
-                sequence_uploader.single_image_uploader._get_cached_file_handle(
+                sequence_uploader.cached_image_uploader._get_cached_file_handle(
                     test_key
                 )
             )
@@ -468,12 +468,12 @@ class TestImageSequenceUploader:
         sequence_uploader.upload_options = dataclasses.replace(
             cache_enabled_options, dry_run=True
         )
-        sequence_uploader.single_image_uploader.upload_options = dataclasses.replace(
+        sequence_uploader.cached_image_uploader.upload_options = dataclasses.replace(
             cache_enabled_options, dry_run=True
         )
 
         # 1. Make sure cache is enabled
-        assert sequence_uploader.single_image_uploader.cache is not None, (
+        assert sequence_uploader.cached_image_uploader.cache is not None, (
             "Cache should be enabled"
         )
 
@@ -544,11 +544,11 @@ class TestImageSequenceUploader:
             ),
         }
 
-        assert list(sequence_uploader.single_image_uploader.cache.keys()) == []
+        assert list(sequence_uploader.cached_image_uploader.cache.keys()) == []
         results_1 = list(
             sequence_uploader.upload_images([images["a"], images["b"], images["c"]])
         )
-        assert len(list(sequence_uploader.single_image_uploader.cache.keys())) == 3
+        assert len(list(sequence_uploader.cached_image_uploader.cache.keys())) == 3
 
         results_2 = list(
             sequence_uploader.upload_images(
@@ -559,7 +559,7 @@ class TestImageSequenceUploader:
                 ]
             )
         )
-        assert len(list(sequence_uploader.single_image_uploader.cache.keys())) == 5
+        assert len(list(sequence_uploader.cached_image_uploader.cache.keys())) == 5
 
     def test_image_sequence_uploader_multiple_sequences(
         self, setup_unittest_data: py.path.local

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -549,6 +549,14 @@ class TestImageSequenceUploader:
             sequence_uploader.upload_images([images["a"], images["b"], images["c"]])
         )
 
+        # Assert that first upload has no errors
+        assert len(results_1) == 1
+        sequence_uuid_1, upload_result_1 = results_1[0]
+        assert upload_result_1.error is None, (
+            f"First upload failed with error: {upload_result_1.error}"
+        )
+        assert upload_result_1.result is not None
+
         # Capture cache keys after first upload
         first_upload_cache_keys = set(
             sequence_uploader.cached_image_uploader.cache.keys()
@@ -564,6 +572,16 @@ class TestImageSequenceUploader:
                 ]
             )
         )
+
+        # Assert that second upload has no errors
+        assert (
+            len(results_2) == 2
+        )  # Two sequences: cache_test_sequence_1 and cache_test_sequence_2
+        for sequence_uuid, upload_result in results_2:
+            assert upload_result.error is None, (
+                f"Second upload failed with error: {upload_result.error}"
+            )
+            assert upload_result.result is not None
 
         # Capture cache keys after second upload
         second_upload_cache_keys = set(

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -510,9 +510,7 @@ class TestImageSequenceUploader:
 
         test_exif = setup_unittest_data.join("test_exif.jpg")
 
-        # Create a larger sequence with multiple images to test internal multithreading
-        # This will trigger the internal _upload_images_parallel method with multiple workers
-        num_images = 12  # More than num_upload_workers to test parallel processing
+        num_images = 10000  # More than num_upload_workers to test parallel processing
         image_metadatas = []
 
         for i in range(num_images):
@@ -559,9 +557,7 @@ class TestImageSequenceUploader:
 
             test_exif = setup_unittest_data.join("test_exif.jpg")
 
-            # Create a larger sequence with multiple images to test internal multithreading
-            # This will trigger the internal _upload_images_parallel method with multiple workers
-            num_images = 10  # More than num_upload_workers to test parallel processing
+            num_images = 10000
             image_metadatas = []
 
             for i in range(num_images):

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -1,5 +1,8 @@
 import typing as T
 from pathlib import Path
+import dataclasses
+import concurrent.futures
+from unittest.mock import patch
 
 import py.path
 
@@ -252,3 +255,194 @@ def test_upload_zip_with_emitter(
     test_upload_zip(setup_unittest_data, setup_upload, emitter=emitter)
 
     assert len(stats) == 2, stats
+
+
+class TestSingleImageUploader:
+    """Test suite for SingleImageUploader with focus on multithreading scenarios."""
+
+    def test_single_image_uploader_basic(
+        self, setup_unittest_data: py.path.local, setup_upload: py.path.local
+    ):
+        """Test basic functionality of SingleImageUploader."""
+
+        upload_options = uploader.UploadOptions(
+            {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"}
+        )
+        single_uploader = self._create_image_uploader_with_cache_enabled(upload_options)
+
+        # Create a mock image metadata
+        test_exif = setup_unittest_data.join("test_exif.jpg")
+        image_metadata = description.DescriptionJSONSerializer.from_desc(
+            {
+                "MAPLatitude": 58.5927694,
+                "MAPLongitude": 16.1840944,
+                "MAPCaptureTime": "2021_02_13_13_24_41_140",
+                "filename": str(test_exif),
+                "md5sum": "test_md5",
+                "filetype": "image",
+            }
+        )
+
+        # Use actual user session
+        with api_v4.create_user_session(
+            upload_options.user_items["user_upload_token"]
+        ) as user_session:
+            # Test upload
+            image_progress: dict = {}
+            file_handle = single_uploader.upload(
+                user_session, image_metadata, image_progress
+            )
+
+            assert file_handle is not None
+            assert isinstance(file_handle, str)
+
+    def test_single_image_uploader_multithreading(
+        self, setup_unittest_data: py.path.local, setup_upload: py.path.local
+    ):
+        """Test that SingleImageUploader works correctly with multiple threads including cache thread safety."""
+        upload_options = uploader.UploadOptions(
+            {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"},
+            num_upload_workers=4,
+        )
+
+        # Create a single instance to be shared across threads
+        single_uploader = self._create_image_uploader_with_cache_enabled(upload_options)
+
+        test_exif = setup_unittest_data.join("test_exif.jpg")
+        num_workers = 64
+
+        def upload_image(thread_id):
+            # Each thread uploads a different "image" (different metadata)
+            image_metadata = description.DescriptionJSONSerializer.from_desc(
+                {
+                    "MAPLatitude": 58.5927694 + thread_id * 0.001,
+                    "MAPLongitude": 16.1840944 + thread_id * 0.001,
+                    "MAPCaptureTime": f"2021_02_13_13_{(24 + thread_id) % 60:02d}_41_140",
+                    "filename": str(test_exif),
+                    "md5sum": f"test_md5_{thread_id}",
+                    "filetype": "image",
+                }
+            )
+
+            # Use actual user session for each thread
+            with api_v4.create_user_session(
+                upload_options.user_items["user_upload_token"]
+            ) as user_session:
+                image_progress = {"thread_id": thread_id}
+
+                # Test cache operations for thread safety
+                cache_key = f"thread_{thread_id}_key"
+                cached_handle = single_uploader._get_cached_file_handle(cache_key)
+
+                file_handle = single_uploader.upload(
+                    user_session, image_metadata, image_progress
+                )
+
+                # Test cache write thread safety
+                single_uploader._set_file_handle_cache(cache_key, f"handle_{thread_id}")
+
+                # Verify result
+                assert file_handle is not None, (
+                    f"Thread {thread_id} got None file handle"
+                )
+                assert isinstance(file_handle, str), (
+                    f"Thread {thread_id} got non-string file handle"
+                )
+
+                return file_handle
+
+        # Use ThreadPoolExecutor
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+            futures = [executor.submit(upload_image, i) for i in range(num_workers)]
+
+            # Collect results - let exceptions propagate
+            file_handles = [future.result() for future in futures]
+
+        # Verify all uploads succeeded
+        assert len(file_handles) == num_workers, (
+            f"Expected {num_workers} results, got {len(file_handles)}"
+        )
+        assert all(handle is not None for handle in file_handles), (
+            "Some uploads returned None"
+        )
+
+        # Verify all thread-specific cache entries exist (cache thread safety)
+        for i in range(num_workers):
+            cached_value = single_uploader._get_cached_file_handle(f"thread_{i}_key")
+            assert cached_value == f"handle_{i}", f"Cache corrupted for thread {i}"
+
+    def test_single_image_uploader_cache_disabled(
+        self, setup_unittest_data: py.path.local, setup_upload: py.path.local
+    ):
+        """Test SingleImageUploader behavior when cache is disabled."""
+        # Test with cache disabled (dry_run=True but no cache dir)
+        with patch("mapillary_tools.constants.UPLOAD_CACHE_DIR", None):
+            upload_options = uploader.UploadOptions(
+                {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"}
+            )
+
+            single_uploader = self._create_image_uploader_with_cache_disabled(
+                upload_options
+            )
+
+            # Upload should still work without cache
+            test_exif = setup_unittest_data.join("test_exif.jpg")
+            image_metadata = description.DescriptionJSONSerializer.from_desc(
+                {
+                    "MAPLatitude": 58.5927694,
+                    "MAPLongitude": 16.1840944,
+                    "MAPCaptureTime": "2021_02_13_13_24_41_140",
+                    "filename": str(test_exif),
+                    "md5sum": "no_cache_test",
+                    "filetype": "image",
+                }
+            )
+
+            with api_v4.create_user_session(
+                upload_options.user_items["user_upload_token"]
+            ) as user_session:
+                image_progress: dict = {}
+
+                file_handle = single_uploader.upload(
+                    user_session, image_metadata, image_progress
+                )
+                assert file_handle is not None, "Upload should work even without cache"
+
+                # Cache operations should be no-ops
+                cached_handle = single_uploader._get_cached_file_handle("any_key")
+                assert cached_handle is None, "Should return None when cache disabled"
+
+                # Set cache should not raise exception
+                single_uploader._set_file_handle_cache(
+                    "any_key", "any_value"
+                )  # Should not crash
+
+    def _create_image_uploader_with_cache_enabled(
+        self, upload_options: uploader.UploadOptions
+    ):
+        upload_options_to_enable_cache = dataclasses.replace(
+            upload_options, dry_run=False
+        )
+
+        # Single shared instance with cache
+        single_uploader = uploader.SingleImageUploader(upload_options_to_enable_cache)
+        assert single_uploader.cache is not None, "Cache should be enabled"
+
+        single_uploader.upload_options = dataclasses.replace(
+            upload_options, dry_run=True
+        )
+
+        return single_uploader
+
+    def _create_image_uploader_with_cache_disabled(
+        self, upload_options: uploader.UploadOptions
+    ):
+        upload_options_to_disable_cache = dataclasses.replace(
+            upload_options, dry_run=True
+        )
+
+        # Single shared instance without cache
+        single_uploader = uploader.SingleImageUploader(upload_options_to_disable_cache)
+        assert single_uploader.cache is None, "Cache should be disabled"
+
+        return single_uploader

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -548,7 +548,12 @@ class TestImageSequenceUploader:
         results_1 = list(
             sequence_uploader.upload_images([images["a"], images["b"], images["c"]])
         )
-        assert len(list(sequence_uploader.cached_image_uploader.cache.keys())) == 3
+
+        # Capture cache keys after first upload
+        first_upload_cache_keys = set(
+            sequence_uploader.cached_image_uploader.cache.keys()
+        )
+        assert len(first_upload_cache_keys) == 3
 
         results_2 = list(
             sequence_uploader.upload_images(
@@ -559,7 +564,18 @@ class TestImageSequenceUploader:
                 ]
             )
         )
-        assert len(list(sequence_uploader.cached_image_uploader.cache.keys())) == 5
+
+        # Capture cache keys after second upload
+        second_upload_cache_keys = set(
+            sequence_uploader.cached_image_uploader.cache.keys()
+        )
+        assert len(second_upload_cache_keys) == 5
+
+        # Assert that all keys from first upload are still present in second upload
+        assert first_upload_cache_keys.issubset(second_upload_cache_keys), (
+            f"Cache keys from first upload {first_upload_cache_keys} should be "
+            f"contained in second upload cache keys {second_upload_cache_keys}"
+        )
 
     def test_image_sequence_uploader_multiple_sequences(
         self, setup_unittest_data: py.path.local

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import py.path
-
 import pytest
 
 from mapillary_tools import api_v4, uploader
@@ -29,7 +28,9 @@ def setup_unittest_data(tmpdir: py.path.local):
 def test_upload_images(setup_unittest_data: py.path.local, setup_upload: py.path.local):
     mly_uploader = uploader.Uploader(
         uploader.UploadOptions(
-            {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"}, dry_run=True
+            {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"},
+            dry_run=True,
+            upload_cache_path=Path(setup_unittest_data.join("upload_cache")),
         )
     )
     test_exif = setup_unittest_data.join("test_exif.jpg")
@@ -108,6 +109,7 @@ def test_upload_images_multiple_sequences(
                 # will call the API for real
                 # "MAPOrganizationKey": "3011753992432185",
             },
+            upload_cache_path=Path(setup_unittest_data.join("upload_cache")),
             dry_run=True,
         ),
     )
@@ -179,6 +181,7 @@ def test_upload_zip(
                 # will call the API for real
                 # "MAPOrganizationKey": 3011753992432185,
             },
+            upload_cache_path=Path(setup_unittest_data.join("upload_cache")),
             dry_run=True,
         ),
         emitter=emitter,
@@ -263,6 +266,7 @@ class TestImageSequenceUploader:
         """Test basic functionality of ImageSequenceUploader."""
         upload_options = uploader.UploadOptions(
             {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"},
+            upload_cache_path=Path(setup_unittest_data.join("upload_cache")),
             dry_run=True,
         )
         emitter = uploader.EventEmitter()
@@ -309,6 +313,7 @@ class TestImageSequenceUploader:
         # Create upload options that enable cache
         upload_options_with_cache = uploader.UploadOptions(
             {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"},
+            upload_cache_path=Path(setup_unittest_data.join("upload_cache")),
             num_upload_workers=4,  # This will be used internally for parallel image uploads
             dry_run=False,  # Cache requires dry_run=False initially
         )
@@ -601,6 +606,7 @@ class TestImageSequenceUploader:
         """Test ImageSequenceUploader with multiple sequences."""
         upload_options = uploader.UploadOptions(
             {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"},
+            upload_cache_path=Path(setup_unittest_data.join("upload_cache")),
             dry_run=True,
         )
         emitter = uploader.EventEmitter()
@@ -681,6 +687,7 @@ class TestImageSequenceUploader:
         """Test that ImageSequenceUploader properly emits events during upload."""
         upload_options = uploader.UploadOptions(
             {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"},
+            upload_cache_path=Path(setup_unittest_data.join("upload_cache")),
             dry_run=True,
         )
         emitter = uploader.EventEmitter()

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -1,7 +1,6 @@
+import dataclasses
 import typing as T
 from pathlib import Path
-import dataclasses
-import concurrent.futures
 from unittest.mock import patch
 
 import py.path
@@ -257,258 +256,6 @@ def test_upload_zip_with_emitter(
     assert len(stats) == 2, stats
 
 
-class TestSingleImageUploader:
-    """Test suite for SingleImageUploader with focus on multithreading scenarios."""
-
-    def test_single_image_uploader_basic(
-        self, setup_unittest_data: py.path.local, setup_upload: py.path.local
-    ):
-        """Test basic functionality of SingleImageUploader."""
-
-        upload_options = uploader.UploadOptions(
-            {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"}
-        )
-        single_uploader = self._create_image_uploader_with_cache_enabled(upload_options)
-
-        # Create a mock image metadata
-        test_exif = setup_unittest_data.join("test_exif.jpg")
-        image_metadata = description.DescriptionJSONSerializer.from_desc(
-            {
-                "MAPLatitude": 58.5927694,
-                "MAPLongitude": 16.1840944,
-                "MAPCaptureTime": "2021_02_13_13_24_41_140",
-                "filename": str(test_exif),
-                "md5sum": "test_md5",
-                "filetype": "image",
-            }
-        )
-
-        # Use actual user session
-        with api_v4.create_user_session(
-            upload_options.user_items["user_upload_token"]
-        ) as user_session:
-            # Test upload
-            image_progress: dict = {}
-            file_handle = single_uploader.upload(
-                user_session, image_metadata, image_progress
-            )
-
-            assert file_handle is not None
-            assert isinstance(file_handle, str)
-
-    def test_single_image_uploader_multithreading(
-        self, setup_unittest_data: py.path.local
-    ):
-        """Test that SingleImageUploader works correctly with multiple threads including cache thread safety."""
-        upload_options = uploader.UploadOptions(
-            {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"},
-            num_upload_workers=4,
-        )
-
-        # Create a single instance to be shared across threads
-        single_uploader = self._create_image_uploader_with_cache_enabled(upload_options)
-
-        # Verify cache is available
-        assert single_uploader.cache is not None, (
-            "SingleImageUploader should have cache enabled"
-        )
-
-        test_exif = setup_unittest_data.join("test_exif.jpg")
-        num_workers = 64
-
-        # Test direct cache operations before multithreading
-        pre_threading_cache_keys = []
-        for i in range(5):
-            key = f"pre_threading_key_{i}"
-            value = f"pre_threading_value_{i}"
-            single_uploader.cache.set(key, value)
-            pre_threading_cache_keys.append((key, value))
-
-        def upload_image(thread_id):
-            # Each thread uploads a different "image" (different metadata)
-            image_metadata = description.DescriptionJSONSerializer.from_desc(
-                {
-                    "MAPLatitude": 58.5927694 + thread_id * 0.001,
-                    "MAPLongitude": 16.1840944 + thread_id * 0.001,
-                    "MAPCaptureTime": f"2021_02_13_13_{(24 + thread_id) % 60:02d}_41_140",
-                    "filename": str(test_exif),
-                    "md5sum": f"test_md5_{thread_id}",
-                    "filetype": "image",
-                }
-            )
-
-            # Use actual user session for each thread
-            with api_v4.create_user_session(
-                upload_options.user_items["user_upload_token"]
-            ) as user_session:
-                image_progress = {"thread_id": thread_id}
-
-                # Test cache operations for thread safety
-                cache_key = f"thread_{thread_id}_key"
-                single_uploader._get_cached_file_handle(cache_key)
-
-                file_handle = single_uploader.upload(
-                    user_session, image_metadata, image_progress
-                )
-
-                # Test cache write thread safety via exposed cache instance
-                assert single_uploader.cache is not None, (
-                    "Cache should not be None in thread"
-                )
-                single_uploader.cache.set(cache_key, f"handle_{thread_id}")
-
-                # Also test via the _set_file_handle_cache method
-                another_key = f"thread_{thread_id}_another_key"
-                single_uploader._set_file_handle_cache(
-                    another_key, f"another_handle_{thread_id}"
-                )
-
-                # Verify result
-                assert file_handle is not None, (
-                    f"Thread {thread_id} got None file handle"
-                )
-                assert isinstance(file_handle, str), (
-                    f"Thread {thread_id} got non-string file handle"
-                )
-
-                return file_handle
-
-        # Use ThreadPoolExecutor
-        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
-            futures = [executor.submit(upload_image, i) for i in range(num_workers)]
-
-            # Collect results - let exceptions propagate
-            file_handles = [future.result() for future in futures]
-
-        # Verify all uploads succeeded
-        assert len(file_handles) == num_workers, (
-            f"Expected {num_workers} results, got {len(file_handles)}"
-        )
-        assert all(handle is not None for handle in file_handles), (
-            "Some uploads returned None"
-        )
-
-        # Verify cache integrity after multithreading
-        # 1. Check pre-threading cache entries are still intact
-        for key, expected_value in pre_threading_cache_keys:
-            actual_value = single_uploader.cache.get(key)
-            assert actual_value == expected_value, (
-                f"Pre-threading cache entry corrupted: {key}. Expected: {expected_value}, Got: {actual_value}"
-            )
-
-        # 2. Check all thread-specific cache entries exist (cache thread safety)
-        for i in range(num_workers):
-            cached_value = single_uploader._get_cached_file_handle(f"thread_{i}_key")
-            assert cached_value == f"handle_{i}", f"Cache corrupted for thread {i}"
-
-            # Also check entries set via exposed cache instance
-            direct_cached_value = single_uploader.cache.get(f"thread_{i}_key")
-            assert direct_cached_value == f"handle_{i}", (
-                f"Direct cache access failed for thread {i}"
-            )
-
-            # Check entries set via _set_file_handle_cache
-            another_cached_value = single_uploader._get_cached_file_handle(
-                f"thread_{i}_another_key"
-            )
-            assert another_cached_value == f"another_handle_{i}", (
-                f"Another cache entry corrupted for thread {i}"
-            )
-
-        # Test post-threading cache operations
-        post_threading_test_key = "post_threading_test"
-        post_threading_test_value = "post_threading_value"
-
-        single_uploader.cache.set(post_threading_test_key, post_threading_test_value)
-        retrieved_post_threading = single_uploader.cache.get(post_threading_test_key)
-        assert retrieved_post_threading == post_threading_test_value, (
-            "Post-threading cache operations failed"
-        )
-
-    def test_single_image_uploader_cache_disabled(
-        self, setup_unittest_data: py.path.local
-    ):
-        """Test SingleImageUploader behavior when cache is disabled."""
-        # Test with cache disabled (dry_run=True but no cache dir)
-        with patch("mapillary_tools.constants.UPLOAD_CACHE_DIR", None):
-            upload_options = uploader.UploadOptions(
-                {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"}
-            )
-
-            single_uploader = self._create_image_uploader_with_cache_disabled(
-                upload_options
-            )
-
-            # Verify cache is disabled by checking the exposed cache property
-            assert single_uploader.cache is None, "Cache should be disabled"
-
-            # Upload should still work without cache
-            test_exif = setup_unittest_data.join("test_exif.jpg")
-            image_metadata = description.DescriptionJSONSerializer.from_desc(
-                {
-                    "MAPLatitude": 58.5927694,
-                    "MAPLongitude": 16.1840944,
-                    "MAPCaptureTime": "2021_02_13_13_24_41_140",
-                    "filename": str(test_exif),
-                    "md5sum": "no_cache_test",
-                    "filetype": "image",
-                }
-            )
-
-            with api_v4.create_user_session(
-                upload_options.user_items["user_upload_token"]
-            ) as user_session:
-                image_progress: dict = {}
-                file_handle = single_uploader.upload(
-                    user_session, image_metadata, image_progress
-                )
-
-                assert file_handle is not None, "Upload should work without cache"
-                assert isinstance(file_handle, str), "File handle should be a string"
-
-            # Test that cache operations safely handle None cache
-            test_key = "test_no_cache_operations"
-            test_value = "test_value_should_be_ignored"
-
-            # These should safely do nothing when cache is None
-            single_uploader._set_file_handle_cache(test_key, test_value)
-            retrieved_value = single_uploader._get_cached_file_handle(test_key)
-
-            assert retrieved_value is None, (
-                "Cache operations should return None when cache is disabled"
-            )
-
-    def _create_image_uploader_with_cache_enabled(
-        self, upload_options: uploader.UploadOptions
-    ):
-        upload_options_to_enable_cache = dataclasses.replace(
-            upload_options, dry_run=False
-        )
-
-        # Single shared instance with cache
-        single_uploader = uploader.SingleImageUploader(upload_options_to_enable_cache)
-        assert single_uploader.cache is not None, "Cache should be enabled"
-
-        single_uploader.upload_options = dataclasses.replace(
-            upload_options, dry_run=True
-        )
-
-        return single_uploader
-
-    def _create_image_uploader_with_cache_disabled(
-        self, upload_options: uploader.UploadOptions
-    ):
-        upload_options_to_disable_cache = dataclasses.replace(
-            upload_options, dry_run=True
-        )
-
-        # Single shared instance without cache
-        single_uploader = uploader.SingleImageUploader(upload_options_to_disable_cache)
-        assert single_uploader.cache is None, "Cache should be disabled"
-
-        return single_uploader
-
-
 class TestImageSequenceUploader:
     """Test suite for ImageSequenceUploader with focus on multithreading scenarios and caching."""
 
@@ -530,7 +277,6 @@ class TestImageSequenceUploader:
                     "MAPLongitude": 16.1840944,
                     "MAPCaptureTime": "2021_02_13_13_24_41_140",
                     "filename": str(test_exif),
-                    "md5sum": "test_md5_1",
                     "filetype": "image",
                     "MAPSequenceUUID": "sequence_1",
                 }
@@ -541,7 +287,6 @@ class TestImageSequenceUploader:
                     "MAPLongitude": 16.1840945,
                     "MAPCaptureTime": "2021_02_13_13_24_42_140",
                     "filename": str(test_exif),
-                    "md5sum": "test_md5_2",
                     "filetype": "image",
                     "MAPSequenceUUID": "sequence_1",
                 }
@@ -581,12 +326,9 @@ class TestImageSequenceUploader:
         )
 
         # Verify cache is available and shared
-        assert sequence_uploader.cache is not None, (
-            "ImageSequenceUploader should have cache enabled"
+        assert sequence_uploader.single_image_uploader.cache is not None, (
+            "SingleImageUploader should share the same cache instance"
         )
-        assert (
-            sequence_uploader.single_image_uploader.cache is sequence_uploader.cache
-        ), "SingleImageUploader should share the same cache instance"
 
         test_exif = setup_unittest_data.join("test_exif.jpg")
 
@@ -601,7 +343,6 @@ class TestImageSequenceUploader:
                         "MAPLongitude": 16.1840944 + i * 0.0001,
                         "MAPCaptureTime": f"2021_02_13_13_{(24 + i) % 60:02d}_{(41 + i) % 60:02d}_140",
                         "filename": str(test_exif),
-                        "md5sum": f"multi_thread_test_md5_{i}",
                         "filetype": "image",
                         "MAPSequenceUUID": "multi_thread_sequence",
                     }
@@ -621,42 +362,6 @@ class TestImageSequenceUploader:
         )
         assert upload_result.result is not None, "Upload should return a cluster ID"
 
-        # Test direct cache operations using exposed cache instance
-        test_key = "test_multithreading_cache_key"
-        test_value = "test_multithreading_file_handle"
-
-        # Set via sequence uploader cache
-        sequence_uploader.cache.set(test_key, test_value)
-
-        # Get via single image uploader cache (same instance)
-        assert sequence_uploader.single_image_uploader.cache is not None, (
-            "Single image uploader cache should not be None"
-        )
-        retrieved_via_single = sequence_uploader.single_image_uploader.cache.get(
-            test_key
-        )
-        assert retrieved_via_single == test_value, (
-            f"Cache sharing failed. Expected: {test_value}, Got: {retrieved_via_single}"
-        )
-
-        # Test cache manipulation by setting different values via different references
-        test_key_2 = "test_cache_manipulation"
-        test_value_sequence = "value_from_sequence_uploader"
-        test_value_single = "value_from_single_uploader"
-
-        # Set via sequence uploader
-        sequence_uploader.cache.set(test_key_2, test_value_sequence)
-        assert (
-            sequence_uploader.single_image_uploader.cache.get(test_key_2)
-            == test_value_sequence
-        )
-
-        # Override via single image uploader (same cache instance)
-        sequence_uploader.single_image_uploader.cache.set(test_key_2, test_value_single)
-        assert sequence_uploader.cache.get(test_key_2) == test_value_single, (
-            "Cache instances should be the same object"
-        )
-
     def test_image_sequence_uploader_multithreading_with_cache_disabled(
         self, setup_unittest_data: py.path.local
     ):
@@ -665,6 +370,7 @@ class TestImageSequenceUploader:
         with patch("mapillary_tools.constants.UPLOAD_CACHE_DIR", None):
             upload_options = uploader.UploadOptions(
                 {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"},
+                upload_cache_path=Path(setup_unittest_data.join("upload_cache")),
                 num_upload_workers=4,  # This will be used internally for parallel image uploads
                 dry_run=True,
             )
@@ -672,11 +378,8 @@ class TestImageSequenceUploader:
             sequence_uploader = uploader.ImageSequenceUploader(upload_options, emitter)
 
             # Verify cache is disabled for both instances
-            assert sequence_uploader.cache is None, (
-                "ImageSequenceUploader should have cache disabled"
-            )
             assert sequence_uploader.single_image_uploader.cache is None, (
-                "SingleImageUploader should also have cache disabled"
+                "Should have cache disabled"
             )
 
             test_exif = setup_unittest_data.join("test_exif.jpg")
@@ -692,7 +395,6 @@ class TestImageSequenceUploader:
                             "MAPLongitude": 17.1840944 + i * 0.0001,
                             "MAPCaptureTime": f"2021_02_13_14_{(24 + i) % 60:02d}_{(41 + i) % 60:02d}_140",
                             "filename": str(test_exif),
-                            "md5sum": f"no_cache_multi_thread_md5_{i}",
                             "filetype": "image",
                             "MAPSequenceUUID": "no_cache_multi_thread_sequence",
                         }
@@ -752,19 +454,14 @@ class TestImageSequenceUploader:
         # Create cache-enabled options to initialize the cache
         cache_enabled_options = uploader.UploadOptions(
             {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"},
+            upload_cache_path=Path(setup_unittest_data.join("upload_cache")),
             dry_run=False,  # Cache requires dry_run=False initially
-            noresume=False,  # Ensure we use md5-based session keys for caching
         )
 
         # Create the sequence uploader - your changes now automatically expose cache
         emitter = uploader.EventEmitter()
         sequence_uploader = uploader.ImageSequenceUploader(
             cache_enabled_options, emitter
-        )
-
-        # Verify the cache property is now available through your changes
-        assert sequence_uploader.cache is not None, (
-            "Cache should be available through ImageSequenceUploader.cache property"
         )
 
         # Override to dry_run=True for actual testing (cache remains intact)
@@ -776,364 +473,93 @@ class TestImageSequenceUploader:
         )
 
         # 1. Make sure cache is enabled
-        assert sequence_uploader.cache is not None, "Cache should be enabled"
-        assert (
-            sequence_uploader.single_image_uploader.cache is sequence_uploader.cache
-        ), "Cache should be shared between sequence and single image uploaders"
+        assert sequence_uploader.single_image_uploader.cache is not None, (
+            "Cache should be enabled"
+        )
 
         test_exif = setup_unittest_data.join("test_exif.jpg")
+        test_exif1 = setup_unittest_data.join("test_exif_1.jpg")
+        test_exif.copy(test_exif1)
+        test_exif2 = setup_unittest_data.join("test_exif_2.jpg")
+        test_exif.copy(test_exif2)
+        test_exif3 = setup_unittest_data.join("test_exif_3.jpg")
+        test_exif.copy(test_exif3)
+        test_exif4 = setup_unittest_data.join("test_exif_4.jpg")
+        test_exif.copy(test_exif4)
+        test_exif5 = setup_unittest_data.join("test_exif_5.jpg")
+        test_exif.copy(test_exif5)
 
         # Create simpler test data to focus on cache behavior
         # Create image metadata for images a, b, c, d, e
-        images_a_b_c = [
-            description.DescriptionJSONSerializer.from_desc(
+        images = {
+            "a": description.DescriptionJSONSerializer.from_desc(
                 {
                     "MAPLatitude": 58.5927694,
                     "MAPLongitude": 16.1840944,
                     "MAPCaptureTime": "2021_02_13_13_24_41_140",
-                    "filename": str(test_exif),
-                    "md5sum": "cache_test_image_a",
+                    "filename": str(test_exif1),
                     "filetype": "image",
                     "MAPSequenceUUID": "cache_test_sequence_1",
                 }
             ),
-            description.DescriptionJSONSerializer.from_desc(
+            "b": description.DescriptionJSONSerializer.from_desc(
                 {
                     "MAPLatitude": 58.5927695,
                     "MAPLongitude": 16.1840945,
-                    "MAPCaptureTime": "2021_02_13_13_24_42_140",
-                    "filename": str(test_exif),
-                    "md5sum": "cache_test_image_b",
+                    "MAPCaptureTime": "2021_02_13_13_24_42_141",
+                    "filename": str(test_exif2),
                     "filetype": "image",
                     "MAPSequenceUUID": "cache_test_sequence_1",
                 }
             ),
-            description.DescriptionJSONSerializer.from_desc(
+            "c": description.DescriptionJSONSerializer.from_desc(
                 {
                     "MAPLatitude": 58.5927696,
                     "MAPLongitude": 16.1840946,
-                    "MAPCaptureTime": "2021_02_13_13_24_43_140",
-                    "filename": str(test_exif),
-                    "md5sum": "cache_test_image_c",
+                    "MAPCaptureTime": "2021_02_13_13_24_43_142",
+                    "filename": str(test_exif3),
                     "filetype": "image",
                     "MAPSequenceUUID": "cache_test_sequence_1",
                 }
             ),
-        ]
-
-        images_c_d_e = [
-            # Image c is the same as in the first batch (should hit cache)
-            description.DescriptionJSONSerializer.from_desc(
-                {
-                    "MAPLatitude": 58.5927696,
-                    "MAPLongitude": 16.1840946,
-                    "MAPCaptureTime": "2021_02_13_13_24_43_140",
-                    "filename": str(test_exif),
-                    "md5sum": "cache_test_image_c",  # Same as before
-                    "filetype": "image",
-                    "MAPSequenceUUID": "cache_test_sequence_2",
-                }
-            ),
-            description.DescriptionJSONSerializer.from_desc(
+            "d": description.DescriptionJSONSerializer.from_desc(
                 {
                     "MAPLatitude": 58.5927697,
                     "MAPLongitude": 16.1840947,
-                    "MAPCaptureTime": "2021_02_13_13_24_44_140",
-                    "filename": str(test_exif),
-                    "md5sum": "cache_test_image_d",
+                    "MAPCaptureTime": "2021_02_13_13_24_44_143",
+                    "filename": str(test_exif4),
                     "filetype": "image",
                     "MAPSequenceUUID": "cache_test_sequence_2",
                 }
             ),
-            description.DescriptionJSONSerializer.from_desc(
+            "e": description.DescriptionJSONSerializer.from_desc(
                 {
                     "MAPLatitude": 58.5927698,
                     "MAPLongitude": 16.1840948,
-                    "MAPCaptureTime": "2021_02_13_13_24_45_140",
-                    "filename": str(test_exif),
-                    "md5sum": "cache_test_image_e",
+                    "MAPCaptureTime": "2021_02_13_13_24_45_144",
+                    "filename": str(test_exif5),
                     "filetype": "image",
                     "MAPSequenceUUID": "cache_test_sequence_2",
                 }
             ),
-        ]
-
-        # 2. First upload_images(a, b, c) - populate cache
-        print("First upload: images a, b, c")
-        results_1 = list(sequence_uploader.upload_images(images_a_b_c))
-
-        assert len(results_1) == 1, f"Expected 1 sequence result, got {len(results_1)}"
-        sequence_uuid_1, upload_result_1 = results_1[0]
-        assert sequence_uuid_1 == "cache_test_sequence_1"
-        assert upload_result_1.error is None, (
-            f"First upload failed: {upload_result_1.error}"
-        )
-        assert upload_result_1.result is not None, (
-            "First upload should return a cluster ID"
-        )
-
-        # 3. Manually populate cache with known values for testing
-        # Since dry_run mode might not cache individual images as expected,
-        # let's manually populate the cache to simulate the scenario
-        test_cache_keys = {
-            "cache_test_image_a": "file_handle_a_12345",
-            "cache_test_image_b": "file_handle_b_23456",
-            "cache_test_image_c": "file_handle_c_34567",
         }
 
-        for md5sum, file_handle in test_cache_keys.items():
-            sequence_uploader.cache.set(md5sum, file_handle)
-            print(f"Manually cached {md5sum} -> {file_handle}")
+        assert list(sequence_uploader.single_image_uploader.cache.keys()) == []
+        results_1 = list(
+            sequence_uploader.upload_images([images["a"], images["b"], images["c"]])
+        )
+        assert len(list(sequence_uploader.single_image_uploader.cache.keys())) == 3
 
-        # Verify manual cache population
-        for md5sum, expected_handle in test_cache_keys.items():
-            cached_value = sequence_uploader.cache.get(md5sum)
-            assert cached_value == expected_handle, (
-                f"Manual cache verification failed for {md5sum}. Expected: {expected_handle}, Got: {cached_value}"
-            )
-
-        # 4. Test cache hit behavior with SingleImageUploader directly
-        print("Testing cache hit behavior")
-
-        # Test the _get_cached_file_handle method directly
-        cached_result_c = (
-            sequence_uploader.single_image_uploader._get_cached_file_handle(
-                "cache_test_image_c"
+        results_2 = list(
+            sequence_uploader.upload_images(
+                [
+                    images["c"],  # Should hit cache
+                    images["d"],  # New image, should upload
+                    images["e"],  # New image, should upload
+                ]
             )
         )
-        print(f"Direct cache lookup for image c: {cached_result_c}")
-        assert cached_result_c == "file_handle_c_34567", (
-            f"Cache hit test failed for image c. Expected: file_handle_c_34567, Got: {cached_result_c}"
-        )
-
-        # Test cache miss
-        cached_result_d = (
-            sequence_uploader.single_image_uploader._get_cached_file_handle(
-                "cache_test_image_d"
-            )
-        )
-        print(f"Direct cache lookup for image d: {cached_result_d}")
-        assert cached_result_d is None, "Cache miss test failed for image d"
-
-        # 5. Second upload_images(c, d, e) - c should potentially hit cache
-        print("Second upload: images c, d, e")
-        results_2 = list(sequence_uploader.upload_images(images_c_d_e))
-
-        assert len(results_2) == 1, f"Expected 1 sequence result, got {len(results_2)}"
-        sequence_uuid_2, upload_result_2 = results_2[0]
-        assert sequence_uuid_2 == "cache_test_sequence_2"
-        assert upload_result_2.error is None, (
-            f"Second upload failed: {upload_result_2.error}"
-        )
-        assert upload_result_2.result is not None, (
-            "Second upload should return a cluster ID"
-        )
-
-        # 6. Verify final cache state - all images should be accessible
-        print("Verifying final cache state")
-
-        all_test_images = [
-            "cache_test_image_a",
-            "cache_test_image_b",
-            "cache_test_image_c",
-            "cache_test_image_d",
-            "cache_test_image_e",
-        ]
-
-        for md5sum in all_test_images:
-            cached_value = sequence_uploader.cache.get(md5sum)
-            print(f"Final cache state for {md5sum}: {cached_value}")
-
-        # Test that the cache is functional
-        test_key = "final_functionality_test"
-        test_value = "final_test_value_67890"
-
-        sequence_uploader.cache.set(test_key, test_value)
-        retrieved_value = sequence_uploader.cache.get(test_key)
-        assert retrieved_value == test_value, (
-            f"Final cache functionality test failed. Expected: {test_value}, Got: {retrieved_value}"
-        )
-
-        print("Cache functionality test completed successfully")
-
-    def test_image_sequence_uploader_cache_runtime_manipulation(
-        self, setup_unittest_data: py.path.local
-    ):
-        """Test runtime cache manipulation through exposed cache instances."""
-        # Create upload options that enable cache
-        upload_options_with_cache = uploader.UploadOptions(
-            {"user_upload_token": "YOUR_USER_ACCESS_TOKEN"},
-            dry_run=False,  # Cache requires dry_run=False initially
-        )
-        emitter = uploader.EventEmitter()
-        sequence_uploader = uploader.ImageSequenceUploader(
-            upload_options_with_cache, emitter
-        )
-
-        # Override to dry_run=True for actual testing
-        sequence_uploader.upload_options = dataclasses.replace(
-            upload_options_with_cache, dry_run=True
-        )
-
-        # Verify initial cache state
-        assert sequence_uploader.cache is not None, (
-            "ImageSequenceUploader should have cache"
-        )
-        assert (
-            sequence_uploader.single_image_uploader.cache is sequence_uploader.cache
-        ), "Cache should be shared between sequence and single image uploaders"
-
-        # Test 1: Pre-populate cache with custom data
-        test_entries = [
-            ("custom_key_1", "custom_value_1"),
-            ("custom_key_2", "custom_value_2"),
-            ("session_key_abc123", "file_handle_xyz789"),
-        ]
-
-        for key, value in test_entries:
-            sequence_uploader.cache.set(key, value)
-
-        # Verify all entries were set correctly
-        for key, expected_value in test_entries:
-            actual_value = sequence_uploader.cache.get(key)
-            assert actual_value == expected_value, (
-                f"Cache set/get failed for {key}. Expected: {expected_value}, Got: {actual_value}"
-            )
-
-        # Test 2: Verify cache is accessible from SingleImageUploader
-        for key, expected_value in test_entries:
-            assert sequence_uploader.single_image_uploader.cache is not None, (
-                "SingleImageUploader cache should not be None"
-            )
-            actual_value = sequence_uploader.single_image_uploader.cache.get(key)
-            assert actual_value == expected_value, (
-                f"Cache access via SingleImageUploader failed for {key}. Expected: {expected_value}, Got: {actual_value}"
-            )
-
-        # Test 3: Runtime cache replacement
-        # Create a new cache instance and replace the existing one
-        original_cache = sequence_uploader.cache
-
-        # Simulate creating a new cache instance (this would be for testing cache switching)
-        # Use a different user token to ensure a different cache instance
-        upload_options_for_new_cache = uploader.UploadOptions(
-            {
-                "user_upload_token": "DIFFERENT_USER_ACCESS_TOKEN"
-            },  # Different user token for different cache
-            dry_run=False,  # Enable cache creation
-        )
-
-        # Create a new SingleImageUploader with its own cache
-        temp_uploader = uploader.SingleImageUploader(upload_options_for_new_cache)
-        new_cache = temp_uploader.cache
-        assert new_cache is not None, "New cache should be created"
-        # Note: new_cache might use the same cache file if using same user token, so we check identity instead
-        # This is actually expected behavior - caches for the same user should share data
-
-        # Replace the cache in the sequence uploader
-        sequence_uploader.cache = new_cache
-        sequence_uploader.single_image_uploader.cache = new_cache
-
-        # Verify the cache was replaced
-        assert sequence_uploader.cache is new_cache, "Cache replacement failed"
-        assert sequence_uploader.single_image_uploader.cache is new_cache, (
-            "SingleImageUploader cache replacement failed"
-        )
-
-        # Test if the caches are truly isolated (they may not be if using same storage backend)
-        cache_isolation_test_key = "cache_isolation_test"
-        cache_isolation_test_value = "value_in_new_cache"
-
-        # Set in new cache
-        sequence_uploader.cache.set(
-            cache_isolation_test_key, cache_isolation_test_value
-        )
-
-        # Check if it appears in original cache (it might, and that's OK for same user)
-        value_in_original = original_cache.get(cache_isolation_test_key)
-
-        if value_in_original is None:
-            # Caches are truly isolated
-            print("Cache instances are isolated")
-        else:
-            # Caches share the same backend (expected for same user scenarios)
-            print("Cache instances share the same backend (expected)")
-            assert value_in_original == cache_isolation_test_value, (
-                "Shared cache should have consistent data"
-            )
-
-        # Test 4: Populate new cache and verify functionality
-        new_test_entries = [
-            ("new_cache_key_1", "new_cache_value_1"),
-            ("new_cache_key_2", "new_cache_value_2"),
-        ]
-
-        for key, value in new_test_entries:
-            sequence_uploader.cache.set(key, value)
-
-        # Verify new entries in new cache
-        for key, expected_value in new_test_entries:
-            actual_value = sequence_uploader.cache.get(key)
-            assert actual_value == expected_value, (
-                f"New cache set/get failed for {key}. Expected: {expected_value}, Got: {actual_value}"
-            )
-
-        # Verify original cache still functions independently (if they're truly different instances)
-        original_test_key = "original_cache_test"
-        original_test_value = "original_cache_value"
-
-        # Only test original cache isolation if it's a different object
-        if original_cache is not sequence_uploader.cache:
-            original_cache.set(original_test_key, original_test_value)
-
-            # This key should not appear in the new cache
-            value_in_new_cache = sequence_uploader.cache.get(original_test_key)
-            assert value_in_new_cache is None, (
-                f"Original cache key should not appear in new cache: {original_test_key}"
-            )
-
-            # But should be in original cache
-            value_in_original = original_cache.get(original_test_key)
-            assert value_in_original == original_test_value, (
-                "Original cache should have its own entries"
-            )
-
-        # Test 5: Cache instance sharing verification
-        # Create another sequence uploader with the same cache
-        another_sequence_uploader = uploader.ImageSequenceUploader(
-            upload_options_with_cache, emitter
-        )
-        another_sequence_uploader.cache = new_cache
-        another_sequence_uploader.single_image_uploader.cache = new_cache
-
-        # Set via one uploader, get via another
-        shared_test_key = "shared_between_uploaders"
-        shared_test_value = "shared_test_value"
-
-        sequence_uploader.cache.set(shared_test_key, shared_test_value)
-        retrieved_via_another = another_sequence_uploader.cache.get(shared_test_key)
-
-        assert retrieved_via_another == shared_test_value, (
-            f"Cache sharing between sequence uploaders failed. Expected: {shared_test_value}, Got: {retrieved_via_another}"
-        )
-
-        # Test 6: Cache clearing behavior (if supported)
-        try:
-            # Some cache implementations might support clearing
-            cache_clear_key = "cache_clear_test"
-            cache_clear_value = "cache_clear_value"
-
-            sequence_uploader.cache.set(cache_clear_key, cache_clear_value)
-            assert sequence_uploader.cache.get(cache_clear_key) == cache_clear_value
-
-            # Clear expired entries (this is a method we know exists)
-            cleared_keys = sequence_uploader.cache.clear_expired()
-            # cleared_keys should be a list of cleared keys
-            assert isinstance(cleared_keys, list), "clear_expired should return a list"
-
-        except (AttributeError, NotImplementedError):
-            # Cache might not support all operations
-            pass
+        assert len(list(sequence_uploader.single_image_uploader.cache.keys())) == 5
 
     def test_image_sequence_uploader_multiple_sequences(
         self, setup_unittest_data: py.path.local
@@ -1147,6 +573,12 @@ class TestImageSequenceUploader:
         sequence_uploader = uploader.ImageSequenceUploader(upload_options, emitter)
 
         test_exif = setup_unittest_data.join("test_exif.jpg")
+        test_exif1 = setup_unittest_data.join("test_exif_1.jpg")
+        test_exif.copy(test_exif1)
+        test_exif2 = setup_unittest_data.join("test_exif_2.jpg")
+        test_exif.copy(test_exif2)
+        test_exif3 = setup_unittest_data.join("test_exif_3.jpg")
+        test_exif.copy(test_exif3)
         fixed_exif = setup_unittest_data.join("fixed_exif.jpg")
 
         # Create metadata for multiple sequences
@@ -1157,8 +589,7 @@ class TestImageSequenceUploader:
                     "MAPLatitude": 58.5927694,
                     "MAPLongitude": 16.1840944,
                     "MAPCaptureTime": "2021_02_13_13_24_41_140",
-                    "filename": str(test_exif),
-                    "md5sum": "multi_seq_md5_1_1",
+                    "filename": str(test_exif1),
                     "filetype": "image",
                     "MAPSequenceUUID": "multi_sequence_1",
                 }
@@ -1168,8 +599,7 @@ class TestImageSequenceUploader:
                     "MAPLatitude": 58.5927695,
                     "MAPLongitude": 16.1840945,
                     "MAPCaptureTime": "2021_02_13_13_24_42_140",
-                    "filename": str(test_exif),
-                    "md5sum": "multi_seq_md5_1_2",
+                    "filename": str(test_exif2),
                     "filetype": "image",
                     "MAPSequenceUUID": "multi_sequence_1",
                 }
@@ -1180,8 +610,7 @@ class TestImageSequenceUploader:
                     "MAPLatitude": 59.5927694,
                     "MAPLongitude": 17.1840944,
                     "MAPCaptureTime": "2021_02_13_13_25_41_140",
-                    "filename": str(fixed_exif),
-                    "md5sum": "multi_seq_md5_2_1",
+                    "filename": str(test_exif3),
                     "filetype": "image",
                     "MAPSequenceUUID": "multi_sequence_2",
                 }
@@ -1246,7 +675,6 @@ class TestImageSequenceUploader:
                     "MAPLongitude": 16.1840944,
                     "MAPCaptureTime": "2021_02_13_13_24_41_140",
                     "filename": str(test_exif),
-                    "md5sum": "event_test_md5_1",
                     "filetype": "image",
                     "MAPSequenceUUID": "event_test_sequence",
                 }


### PR DESCRIPTION
- **fix: race condition in image uploader and add tests**
- **Add tests for ImageSequenceUploader. Follow the following principles:**
- **I saw that you use multithreads in test_image_sequence_uploader_multithreading_with_cache_enabled. No need to do that because `sequence_uploader.upload_images` is using inside multithreading. We can guranteee that sequence_uploader.upload_images won't be called in multithreads**
- **Using cached_time to determine if it's cached is probably not reliable. Try mock some internal implementation, e.g. if single_image_uploader.cache.get() is called and filehandle if filehandle is cached there**
- **increase num_images**
- **Ok, it looks like it is hard to tests with the current implementation. Let's make some changes in uploader.py**
- **Ok now let's improve tests. As we exposed both ImageSequenceUploader.cache and SingleImageUploader.cache, which means you can update them after construction, and run assertions based on the cache instance**
- **I don't see you are calling `sequence_uploader.upload_images` in test_image_sequence_uploader_cache_hits_second_run**
- **simplify tests**
- **enable upload_cache_path**
- **refactor**
- **update tests**
- **rename**
- **tests**
