### PR TITLE
fix: handle HTTP 429 as retriable errors

### DIFF
--- a/mapillary_tools/uploader.py
+++ b/mapillary_tools/uploader.py
@@ -948,10 +948,9 @@ class Uploader:
         begin_offset = progress.get("begin_offset")
         offset = progress.get("offset")
 
-        if not isinstance(ex, KeyboardInterrupt):
-            LOG.warning(
-                f"Error uploading {self._upload_name(progress)} at {offset=} since {begin_offset=}: {ex.__class__.__name__}: {ex}"
-            )
+        LOG.warning(
+            f"Error uploading {self._upload_name(progress)} at {offset=} since {begin_offset=}: {ex.__class__.__name__}: {ex}"
+        )
 
         if retries <= constants.MAX_UPLOAD_RETRIES:
             retriable, retry_after_sec = _is_retriable_exception(ex)


### PR DESCRIPTION
This pull request enhances the upload retry logic in `mapillary_tools/uploader.py` to handle rate-limiting and server errors more robustly. The main improvements include more precise parsing of HTTP response headers and error bodies to determine retryability and wait times, and refactoring the retry logic to support these changes.

**Retry Logic Improvements:**

* Refactored `_is_retriable_exception` to return a tuple `(retriable: bool, retry_after_sec: int)` instead of just a boolean, enabling more granular control over retry timing based on server responses and headers. Added comprehensive docstring and test examples.
* Added `_parse_backoff` and `_parse_retry_after_from_header` helpers to extract backoff durations from JSON responses and the `Retry-After` HTTP header, supporting both integer seconds and RFC 2822 date formats.
* Improved handling of HTTP 429 (rate limit) and 5xx (server) errors to always retry with an appropriate delay, even if the error body marks them as non-retriable, following best practices for rate-limited APIs.

**Uploader Exception Handling:**

* Updated `_handle_upload_exception` to use the new retry logic, including dynamic sleep durations based on server-provided backoff and `Retry-After` values.

**Dependencies:**

* Added imports for `datetime` and `email.utils` to support parsing of `Retry-After` header values.