### PR TITLE
 Add unit tests to increase coverage from 65% to 67%

### DIFF
--- a/tests/unit/test_api_v4.py
+++ b/tests/unit/test_api_v4.py
@@ -1,0 +1,116 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from mapillary_tools import api_v4
+
+
+class TestCreateSessions:
+    def test_create_user_session_sets_oauth_header(self):
+        session = api_v4.create_user_session("test_token_123")
+        assert session.headers["Authorization"] == "OAuth test_token_123"
+
+    def test_create_client_session_sets_oauth_header(self):
+        session = api_v4.create_client_session()
+        assert session.headers["Authorization"].startswith("OAuth ")
+
+
+class TestIsAuthError:
+    def _make_response(self, status_code: int, json_data=None):
+        resp = MagicMock(spec=requests.Response)
+        resp.status_code = status_code
+        if json_data is not None:
+            resp.json.return_value = json_data
+        else:
+            resp.json.side_effect = Exception("no json")
+        return resp
+
+    def test_401_is_auth_error(self):
+        resp = self._make_response(401)
+        assert api_v4.is_auth_error(resp) is True
+
+    def test_403_is_auth_error(self):
+        resp = self._make_response(403)
+        assert api_v4.is_auth_error(resp) is True
+
+    def test_400_with_not_authorized_type(self):
+        resp = self._make_response(
+            400,
+            json_data={"debug_info": {"type": "NotAuthorizedError"}},
+        )
+        assert api_v4.is_auth_error(resp) is True
+
+    def test_400_without_auth_type(self):
+        resp = self._make_response(
+            400,
+            json_data={"debug_info": {"type": "SomeOtherError"}},
+        )
+        assert api_v4.is_auth_error(resp) is False
+
+    def test_400_no_json(self):
+        resp = self._make_response(400)
+        assert api_v4.is_auth_error(resp) is False
+
+    def test_200_is_not_auth_error(self):
+        resp = self._make_response(200)
+        assert api_v4.is_auth_error(resp) is False
+
+    def test_500_is_not_auth_error(self):
+        resp = self._make_response(500)
+        assert api_v4.is_auth_error(resp) is False
+
+
+class TestExtractAuthErrorMessage:
+    def _make_auth_response(self, status_code: int, json_data=None, text: str = ""):
+        resp = MagicMock(spec=requests.Response)
+        resp.status_code = status_code
+        resp.text = text
+        if json_data is not None:
+            resp.json.return_value = json_data
+        else:
+            resp.json.side_effect = Exception("no json")
+        return resp
+
+    def test_graph_api_error_message(self):
+        resp = self._make_auth_response(
+            401,
+            json_data={"error": {"message": "Invalid token"}},
+        )
+        assert api_v4.extract_auth_error_message(resp) == "Invalid token"
+
+    def test_upload_service_error_message(self):
+        resp = self._make_auth_response(
+            403,
+            json_data={"debug_info": {"message": "Forbidden access"}},
+        )
+        assert api_v4.extract_auth_error_message(resp) == "Forbidden access"
+
+    def test_fallback_to_text(self):
+        resp = self._make_auth_response(
+            401,
+            json_data={},
+            text="Unauthorized",
+        )
+        assert api_v4.extract_auth_error_message(resp) == "Unauthorized"
+
+    def test_no_json_fallback(self):
+        resp = self._make_auth_response(
+            401,
+            text="Auth failed",
+        )
+        assert api_v4.extract_auth_error_message(resp) == "Auth failed"
+
+
+class TestJsonifyResponse:
+    def test_invalid_json_raises_http_content_error(self):
+        resp = MagicMock(spec=requests.Response)
+        resp.json.side_effect = requests.JSONDecodeError("err", "", 0)
+        with pytest.raises(api_v4.HTTPContentError) as exc_info:
+            api_v4.jsonify_response(resp)
+        assert exc_info.value.response is resp

--- a/tests/unit/test_gpmf_gps_filter.py
+++ b/tests/unit/test_gpmf_gps_filter.py
@@ -1,0 +1,229 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import statistics
+
+import pytest
+
+from mapillary_tools.geo import Point
+from mapillary_tools.gpmf import gps_filter
+from mapillary_tools.gpmf.gpmf_gps_filter import remove_noisy_points, remove_outliers
+from mapillary_tools.telemetry import GPSFix, GPSPoint
+
+
+def _make_point(time: float, lat: float, lon: float) -> Point:
+    return Point(time=time, lat=lat, lon=lon, alt=None, angle=None)
+
+
+def _make_gps_point(
+    time: float,
+    lat: float,
+    lon: float,
+    fix: GPSFix | None = GPSFix.FIX_3D,
+    precision: float | None = 100,
+    ground_speed: float | None = 5.0,
+) -> GPSPoint:
+    return GPSPoint(
+        time=time,
+        lat=lat,
+        lon=lon,
+        alt=None,
+        angle=None,
+        epoch_time=None,
+        fix=fix,
+        precision=precision,
+        ground_speed=ground_speed,
+    )
+
+
+# --- Tests for gps_filter module ---
+
+
+class TestCalculatePointSpeed:
+    def test_same_point_zero_time(self):
+        p = _make_point(0.0, 48.0, 11.0)
+        speed = gps_filter.calculate_point_speed(p, p)
+        assert speed == float("inf")
+
+    def test_same_point_different_time(self):
+        p1 = _make_point(0.0, 48.0, 11.0)
+        p2 = _make_point(10.0, 48.0, 11.0)
+        speed = gps_filter.calculate_point_speed(p1, p2)
+        assert speed == 0.0
+
+    def test_speed_calculation(self):
+        p1 = _make_point(0.0, 0.0, 0.0)
+        p2 = _make_point(10.0, 0.001, 0.0)  # ~111 meters
+        speed = gps_filter.calculate_point_speed(p1, p2)
+        assert 10 < speed < 12  # ~11.1 m/s
+
+
+class TestSplitIf:
+    def test_empty_list(self):
+        assert gps_filter.split_if([], lambda a, b: True) == []
+
+    def test_single_point(self):
+        p = _make_point(0.0, 0.0, 0.0)
+        result = gps_filter.split_if([p], lambda a, b: True)
+        assert len(result) == 1
+        assert result[0] == [p]
+
+    def test_no_splits(self):
+        points = [_make_point(float(i), 0.0, 0.0) for i in range(5)]
+        result = gps_filter.split_if(points, lambda a, b: False)
+        assert len(result) == 1
+        assert len(result[0]) == 5
+
+    def test_split_every_point(self):
+        points = [_make_point(float(i), 0.0, 0.0) for i in range(5)]
+        result = gps_filter.split_if(points, lambda a, b: True)
+        assert len(result) == 5
+        for seq in result:
+            assert len(seq) == 1
+
+
+class TestDistanceGt:
+    def test_close_points_not_split(self):
+        decider = gps_filter.distance_gt(100000)
+        p1 = _make_point(0.0, 48.0, 11.0)
+        p2 = _make_point(1.0, 48.001, 11.001)
+        assert decider(p1, p2) is False
+
+    def test_far_points_split(self):
+        decider = gps_filter.distance_gt(100)
+        p1 = _make_point(0.0, 0.0, 0.0)
+        p2 = _make_point(1.0, 1.0, 1.0)
+        assert decider(p1, p2) is True
+
+
+class TestSpeedLe:
+    def test_slow_speed_true(self):
+        decider = gps_filter.speed_le(1000)
+        p1 = _make_point(0.0, 48.0, 11.0)
+        p2 = _make_point(10.0, 48.001, 11.001)
+        assert decider(p1, p2) is True
+
+    def test_fast_speed_false(self):
+        decider = gps_filter.speed_le(0.001)
+        p1 = _make_point(0.0, 0.0, 0.0)
+        p2 = _make_point(1.0, 1.0, 1.0)
+        assert decider(p1, p2) is False
+
+
+class TestUpperWhiskerEdge:
+    def test_raises_on_single_value(self):
+        with pytest.raises(statistics.StatisticsError):
+            gps_filter.upper_whisker([1])
+
+    def test_even_length(self):
+        # [1, 2, 3, 4] -> q1=1.5, q3=3.5, irq=2, upper=3.5+3=6.5
+        assert gps_filter.upper_whisker([1, 2, 3, 4]) == 6.5
+
+    def test_odd_length(self):
+        # [1, 2, 3, 4, 5] -> q1=median([1,2])=1.5, q3=median([4,5])=4.5, irq=3, upper=4.5+4.5=9.0
+        assert gps_filter.upper_whisker([1, 2, 3, 4, 5]) == 9.0
+
+
+# --- Tests for gpmf_gps_filter module ---
+
+
+class TestRemoveNoisyPoints:
+    def test_empty_sequence(self):
+        result = remove_noisy_points([])
+        assert list(result) == []
+
+    def test_all_good_points(self):
+        points = [
+            _make_gps_point(
+                float(i), 48.0 + i * 0.0001, 11.0, fix=GPSFix.FIX_3D, precision=100
+            )
+            for i in range(10)
+        ]
+        result = remove_noisy_points(points)
+        assert len(result) == len(points)
+
+    def test_filters_bad_fix(self):
+        good_0 = _make_gps_point(0.0, 48.0, 11.0, fix=GPSFix.FIX_3D)
+        bad_1 = _make_gps_point(1.0, 48.001, 11.001, fix=GPSFix.NO_FIX)
+        good_2 = _make_gps_point(2.0, 48.002, 11.002, fix=GPSFix.FIX_3D)
+        result = list(remove_noisy_points([good_0, bad_1, good_2]))
+        # NO_FIX point should be removed; FIX_3D points kept
+        assert bad_1 not in result
+        assert good_0 in result
+        assert good_2 in result
+
+    def test_filters_high_precision(self):
+        good_0 = _make_gps_point(0.0, 48.0, 11.0, precision=100)
+        bad_1 = _make_gps_point(1.0, 48.001, 11.001, precision=9999)  # Very high DOP
+        good_2 = _make_gps_point(2.0, 48.002, 11.002, precision=100)
+        result = list(remove_noisy_points([good_0, bad_1, good_2]))
+        # High DOP point should be removed; low DOP points kept
+        assert bad_1 not in result
+        assert good_0 in result
+        assert good_2 in result
+
+    def test_none_fix_kept(self):
+        """Points without GPS fix info should be kept."""
+        points = [
+            _make_gps_point(0.0, 48.0, 11.0, fix=None),
+            _make_gps_point(1.0, 48.001, 11.001, fix=None),
+        ]
+        result = remove_noisy_points(points)
+        assert len(result) == 2
+
+    def test_none_precision_kept(self):
+        """Points without precision info should be kept."""
+        points = [
+            _make_gps_point(0.0, 48.0, 11.0, precision=None),
+            _make_gps_point(1.0, 48.001, 11.001, precision=None),
+        ]
+        result = remove_noisy_points(points)
+        assert len(result) == 2
+
+
+class TestRemoveOutliers:
+    def test_short_sequence_unchanged(self):
+        points = [
+            _make_gps_point(0.0, 48.0, 11.0),
+        ]
+        result = remove_outliers(points)
+        assert len(result) == 1
+
+    def test_no_ground_speed_returns_original(self):
+        points = [
+            _make_gps_point(0.0, 48.0, 11.0, ground_speed=None),
+            _make_gps_point(1.0, 48.001, 11.001, ground_speed=None),
+            _make_gps_point(2.0, 48.002, 11.002, ground_speed=None),
+        ]
+        result = remove_outliers(points)
+        assert len(result) == len(points)
+
+    def test_consistent_sequence_kept(self):
+        points = [
+            _make_gps_point(
+                float(i), 48.0 + i * 0.0001, 11.0 + i * 0.0001, ground_speed=5.0
+            )
+            for i in range(10)
+        ]
+        result = remove_outliers(points)
+        assert len(result) == len(points)
+
+    def test_outlier_removed(self):
+        """A point far away from a consistent cluster should be dropped."""
+        # 9 points in a tight cluster, then 1 point far away
+        cluster = [
+            _make_gps_point(
+                float(i), 48.0 + i * 0.00001, 11.0 + i * 0.00001, ground_speed=1.0
+            )
+            for i in range(9)
+        ]
+        outlier = _make_gps_point(9.0, 10.0, 10.0, ground_speed=1.0)
+        result = remove_outliers(cluster + [outlier])
+        # The outlier is far from the cluster and should be removed
+        assert len(result) < len(cluster) + 1
+        # The cluster points should survive
+        assert len(result) >= len(cluster)

--- a/tests/unit/test_gpx_serializer.py
+++ b/tests/unit/test_gpx_serializer.py
@@ -1,0 +1,216 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from mapillary_tools.geo import Point
+from mapillary_tools.serializer.gpx import GPXSerializer
+from mapillary_tools.telemetry import CAMMGPSPoint, GPSFix, GPSPoint
+from mapillary_tools.types import (
+    ErrorMetadata,
+    FileType,
+    ImageMetadata,
+    VideoMetadata,
+)
+
+
+def _make_image(
+    filename: str,
+    time: float,
+    lat: float,
+    lon: float,
+    alt: float = 100.0,
+    seq_uuid: str | None = None,
+) -> ImageMetadata:
+    return ImageMetadata(
+        time=time,
+        lat=lat,
+        lon=lon,
+        alt=alt,
+        angle=45.0,
+        filename=Path(filename),
+        MAPSequenceUUID=seq_uuid,
+        MAPFilename=filename,
+    )
+
+
+def _make_video(filename: str, points: list[Point]) -> VideoMetadata:
+    return VideoMetadata(
+        filename=Path(filename),
+        filetype=FileType.CAMM,
+        points=points,
+    )
+
+
+def _make_error(filename: str) -> ErrorMetadata:
+    return ErrorMetadata(
+        filename=Path(filename),
+        filetype=FileType.IMAGE,
+        error=ValueError("test error"),
+    )
+
+
+def _parse_gpx(data: bytes) -> ET.Element:
+    return ET.fromstring(data.decode("utf-8"))
+
+
+class TestGPXSerializerSerialize:
+    def test_empty_metadatas(self):
+        result = GPXSerializer.serialize([])
+        root = _parse_gpx(result)
+        assert root.tag.endswith("gpx")
+        # No tracks
+        tracks = root.findall(".//{http://www.topografix.com/GPX/1/1}trk")
+        assert len(tracks) == 0
+
+    def test_single_image(self):
+        img = _make_image("img1.jpg", time=1000.0, lat=48.0, lon=11.0, seq_uuid="seq1")
+        result = GPXSerializer.serialize([img])
+        root = _parse_gpx(result)
+        tracks = root.findall(".//{http://www.topografix.com/GPX/1/1}trk")
+        assert len(tracks) == 1
+        points = root.findall(".//{http://www.topografix.com/GPX/1/1}trkpt")
+        assert len(points) == 1
+        assert float(points[0].attrib["lat"]) == 48.0
+        assert float(points[0].attrib["lon"]) == 11.0
+
+    def test_multiple_images_same_sequence(self):
+        imgs = [
+            _make_image("img1.jpg", time=1000.0, lat=48.0, lon=11.0, seq_uuid="seq1"),
+            _make_image("img2.jpg", time=1001.0, lat=48.1, lon=11.1, seq_uuid="seq1"),
+        ]
+        result = GPXSerializer.serialize(imgs)
+        root = _parse_gpx(result)
+        tracks = root.findall(".//{http://www.topografix.com/GPX/1/1}trk")
+        assert len(tracks) == 1
+        points = root.findall(".//{http://www.topografix.com/GPX/1/1}trkpt")
+        assert len(points) == 2
+
+    def test_multiple_sequences(self):
+        imgs = [
+            _make_image("img1.jpg", time=1000.0, lat=48.0, lon=11.0, seq_uuid="seq1"),
+            _make_image("img2.jpg", time=2000.0, lat=49.0, lon=12.0, seq_uuid="seq2"),
+        ]
+        result = GPXSerializer.serialize(imgs)
+        root = _parse_gpx(result)
+        tracks = root.findall(".//{http://www.topografix.com/GPX/1/1}trk")
+        assert len(tracks) == 2
+
+    def test_video_metadata(self):
+        pts = [
+            Point(time=1.0, lat=48.0, lon=11.0, alt=100.0, angle=0.0),
+            Point(time=2.0, lat=48.1, lon=11.1, alt=110.0, angle=10.0),
+        ]
+        video = _make_video("video.mp4", pts)
+        result = GPXSerializer.serialize([video])
+        root = _parse_gpx(result)
+        tracks = root.findall(".//{http://www.topografix.com/GPX/1/1}trk")
+        assert len(tracks) == 1
+        points = root.findall(".//{http://www.topografix.com/GPX/1/1}trkpt")
+        assert len(points) == 2
+
+    def test_error_metadata(self):
+        err = _make_error("bad.jpg")
+        result = GPXSerializer.serialize([err])
+        root = _parse_gpx(result)
+        tracks = root.findall(".//{http://www.topografix.com/GPX/1/1}trk")
+        assert len(tracks) == 1
+        # Error tracks have no track points
+        points = root.findall(".//{http://www.topografix.com/GPX/1/1}trkpt")
+        assert len(points) == 0
+
+    def test_mixed_metadatas(self):
+        img = _make_image("img1.jpg", time=1000.0, lat=48.0, lon=11.0, seq_uuid="s1")
+        pts = [Point(time=1.0, lat=49.0, lon=12.0, alt=100.0, angle=0.0)]
+        video = _make_video("video.mp4", pts)
+        err = _make_error("bad.jpg")
+        result = GPXSerializer.serialize([img, video, err])
+        root = _parse_gpx(result)
+        tracks = root.findall(".//{http://www.topografix.com/GPX/1/1}trk")
+        # 1 error track + 1 image sequence track + 1 video track
+        assert len(tracks) == 3
+
+    def test_serialize_returns_utf8_bytes(self):
+        result = GPXSerializer.serialize([])
+        assert isinstance(result, bytes)
+        text = result.decode("utf-8")
+        assert "<?xml" in text
+
+
+class TestGPXSerializerAsGPXPoint:
+    def test_basic_point(self):
+        p = Point(time=1000.0, lat=48.0, lon=11.0, alt=500.0, angle=90.0)
+        gpx_pt = GPXSerializer.as_gpx_point(p)
+        assert gpx_pt.latitude == 48.0
+        assert gpx_pt.longitude == 11.0
+        assert gpx_pt.elevation == 500.0
+        assert gpx_pt.time is not None
+
+    def test_image_metadata_point_has_name(self):
+        img = _make_image("photo.jpg", time=1000.0, lat=48.0, lon=11.0)
+        gpx_pt = GPXSerializer.as_gpx_point(img)
+        assert gpx_pt.name == "photo.jpg"
+
+    def test_camm_gps_point_uses_gps_epoch_time(self):
+        p = CAMMGPSPoint(
+            time=5.0,
+            lat=48.0,
+            lon=11.0,
+            alt=100.0,
+            angle=0.0,
+            time_gps_epoch=1700000000.0,
+            gps_fix_type=3,
+            horizontal_accuracy=1.0,
+            vertical_accuracy=1.0,
+            velocity_east=0.0,
+            velocity_north=0.0,
+            velocity_up=0.0,
+            speed_accuracy=0.5,
+        )
+        gpx_pt = GPXSerializer.as_gpx_point(p)
+        # time should be based on time_gps_epoch, not the video time (5.0)
+        assert gpx_pt.time is not None
+        assert gpx_pt.time.timestamp() == 1700000000.0
+
+    def test_gps_point_with_epoch_time(self):
+        p = GPSPoint(
+            time=5.0,
+            lat=48.0,
+            lon=11.0,
+            alt=100.0,
+            angle=0.0,
+            epoch_time=1700000000.0,
+            fix=GPSFix.FIX_3D,
+            precision=1.0,
+            ground_speed=10.0,
+        )
+        gpx_pt = GPXSerializer.as_gpx_point(p)
+        assert gpx_pt.time is not None
+        assert gpx_pt.time.timestamp() == 1700000000.0
+
+    def test_gps_point_without_epoch_time(self):
+        p = GPSPoint(
+            time=1000.0,
+            lat=48.0,
+            lon=11.0,
+            alt=100.0,
+            angle=0.0,
+            epoch_time=None,
+            fix=GPSFix.FIX_3D,
+            precision=1.0,
+            ground_speed=10.0,
+        )
+        gpx_pt = GPXSerializer.as_gpx_point(p)
+        # Falls through without setting epoch_time; uses original time
+        assert gpx_pt.time is not None
+        assert gpx_pt.time.timestamp() == 1000.0
+
+    def test_point_with_none_alt(self):
+        p = Point(time=1000.0, lat=48.0, lon=11.0, alt=None, angle=None)
+        gpx_pt = GPXSerializer.as_gpx_point(p)
+        assert gpx_pt.elevation is None

--- a/tests/unit/test_history.py
+++ b/tests/unit/test_history.py
@@ -1,0 +1,150 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mapillary_tools import history, types
+
+
+class TestValidateHexdigits:
+    def test_valid_md5sum(self):
+        # Should not raise
+        history._validate_hexdigits("abcdef1234567890")
+
+    def test_valid_short_hex(self):
+        history._validate_hexdigits("abcd")
+
+    def test_too_short_raises(self):
+        with pytest.raises(ValueError, match="Invalid md5sum"):
+            history._validate_hexdigits("abc")
+
+    def test_non_hex_raises(self):
+        with pytest.raises(ValueError, match="Invalid md5sum"):
+            history._validate_hexdigits("xyz123")
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="Invalid md5sum"):
+            history._validate_hexdigits("")
+
+
+class TestHistoryDescPath:
+    def test_returns_path_with_subfolder(self):
+        path = history.history_desc_path("aabbccdd")
+        assert "aa" in str(path)
+        assert path.name == "bbccdd.json"
+
+    def test_long_md5sum(self):
+        md5 = "d41d8cd98f00b204e9800998ecf8427e"
+        path = history.history_desc_path(md5)
+        assert path.name == md5[2:] + ".json"
+        assert path.parent.name == "d4"
+
+
+class TestReadHistoryRecord:
+    def test_returns_none_when_no_history_path(self):
+        with patch.object(history.constants, "MAPILLARY_UPLOAD_HISTORY_PATH", ""):
+            result = history.read_history_record("aabbccdd")
+            assert result is None
+
+    def test_returns_none_when_file_not_found(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(
+                history.constants,
+                "MAPILLARY_UPLOAD_HISTORY_PATH",
+                tmpdir,
+            ):
+                result = history.read_history_record("aabbccdd")
+                assert result is None
+
+    def test_reads_valid_history(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(
+                history.constants,
+                "MAPILLARY_UPLOAD_HISTORY_PATH",
+                tmpdir,
+            ):
+                path = history.history_desc_path("aabbccdd")
+                path.parent.mkdir(parents=True, exist_ok=True)
+                record = {"params": {"key": "val"}, "summary": {"count": 1}}
+                with open(path, "w") as fp:
+                    json.dump(record, fp)
+
+                result = history.read_history_record("aabbccdd")
+                assert result is not None
+                assert result["params"]["key"] == "val"
+
+    def test_returns_none_on_corrupt_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(
+                history.constants,
+                "MAPILLARY_UPLOAD_HISTORY_PATH",
+                tmpdir,
+            ):
+                path = history.history_desc_path("aabbccdd")
+                path.parent.mkdir(parents=True, exist_ok=True)
+                with open(path, "w") as fp:
+                    fp.write("not valid json{{{")
+
+                result = history.read_history_record("aabbccdd")
+                assert result is None
+
+
+class TestWriteHistory:
+    def test_write_history_creates_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(
+                history.constants,
+                "MAPILLARY_UPLOAD_HISTORY_PATH",
+                tmpdir,
+            ):
+                history.write_history(
+                    "aabbccdd",
+                    params={"user": "test"},
+                    summary={"uploaded": 5},
+                )
+                path = history.history_desc_path("aabbccdd")
+                assert path.exists()
+                with open(path) as fp:
+                    data = json.load(fp)
+                assert data["params"]["user"] == "test"
+                assert data["summary"]["uploaded"] == 5
+
+    def test_write_history_no_path(self):
+        with patch.object(history.constants, "MAPILLARY_UPLOAD_HISTORY_PATH", ""):
+            # Should be a no-op
+            history.write_history("aabbccdd", params={}, summary={})
+
+    def test_write_history_with_metadatas(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(
+                history.constants,
+                "MAPILLARY_UPLOAD_HISTORY_PATH",
+                tmpdir,
+            ):
+                metadata = types.ImageMetadata(
+                    time=1000.0,
+                    lat=48.0,
+                    lon=11.0,
+                    alt=100.0,
+                    angle=45.0,
+                    filename=Path("img.jpg"),
+                    MAPFilename="img.jpg",
+                )
+                history.write_history(
+                    "aabbccdd",
+                    params={},
+                    summary={},
+                    metadatas=[metadata],
+                )
+                path = history.history_desc_path("aabbccdd")
+                with open(path) as fp:
+                    data = json.load(fp)
+                assert "descs" in data
+                assert len(data["descs"]) == 1

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -1,0 +1,142 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+from unittest.mock import MagicMock
+
+import requests
+
+from mapillary_tools import http
+
+
+class TestTruncate:
+    def test_short_string_unchanged(self):
+        assert http._truncate("hello") == "hello"
+
+    def test_long_string_truncated(self):
+        s = "a" * 300
+        result = http._truncate(s, limit=256)
+        assert len(result) < 300
+        assert "truncated" in result
+        assert "44 chars truncated" in result
+
+    def test_short_bytes_unchanged(self):
+        assert http._truncate(b"hello") == b"hello"
+
+    def test_long_bytes_utf8_decodable_truncated(self):
+        b = b"a" * 300
+        result = http._truncate(b, limit=256)
+        assert isinstance(result, str)
+        assert "truncated" in result
+
+    def test_long_bytes_not_utf8_decodable(self):
+        b = bytes(range(256)) * 2  # 512 bytes, not valid utf-8
+        result = http._truncate(b, limit=256)
+        assert isinstance(result, bytes)
+        assert b"truncated" in result
+
+    def test_exact_limit_not_truncated(self):
+        s = "a" * 256
+        result = http._truncate(s, limit=256)
+        assert result == s
+
+
+class TestSanitize:
+    def test_authorization_redacted(self):
+        result = http._sanitize({"Authorization": "Bearer secret_token"})
+        assert result["Authorization"] == "[REDACTED]"
+
+    def test_cookie_redacted(self):
+        result = http._sanitize({"Cookie": "session=abc123"})
+        assert result["Cookie"] == "[REDACTED]"
+
+    def test_access_token_underscore_redacted(self):
+        result = http._sanitize({"access_token": "tok123"})
+        assert result["access_token"] == "[REDACTED]"
+
+    def test_access_token_hyphen_redacted(self):
+        result = http._sanitize({"Access-Token": "tok123"})
+        assert result["Access-Token"] == "[REDACTED]"
+
+    def test_x_fb_access_token_redacted(self):
+        result = http._sanitize({"X-FB-Access-Token": "tok456"})
+        assert result["X-FB-Access-Token"] == "[REDACTED]"
+
+    def test_user_upload_token_redacted(self):
+        result = http._sanitize({"user_upload_token": "tok789"})
+        assert result["user_upload_token"] == "[REDACTED]"
+
+    def test_password_redacted(self):
+        result = http._sanitize({"password": "secret"})
+        assert result["password"] == "[REDACTED]"
+
+    def test_non_sensitive_header_kept(self):
+        result = http._sanitize({"Content-Type": "application/json"})
+        assert result["Content-Type"] == "application/json"
+
+    def test_long_value_truncated(self):
+        result = http._sanitize({"X-Data": "x" * 500})
+        assert "truncated" in result["X-Data"]
+
+    def test_non_string_value_kept(self):
+        result = http._sanitize({"X-Count": 42})
+        assert result["X-Count"] == 42
+
+
+class TestTruncateResponseContent:
+    def _make_response(
+        self, content: bytes = b"", json_data=None, status_code: int = 200
+    ):
+        resp = MagicMock(spec=requests.Response)
+        resp.content = content
+        resp.status_code = status_code
+        if json_data is not None:
+            resp.json.return_value = json_data
+        else:
+            resp.json.side_effect = requests.JSONDecodeError("", "", 0)
+        return resp
+
+    def test_json_dict_response_sanitized_and_serialized(self):
+        resp = self._make_response(json_data={"key": "value"})
+        result = http._truncate_response_content(resp)
+        assert isinstance(result, str)
+        assert '"key"' in result
+        assert '"value"' in result
+
+    def test_json_dict_with_sensitive_keys_redacted(self):
+        resp = self._make_response(json_data={"authorization": "secret", "data": "ok"})
+        result = http._truncate_response_content(resp)
+        assert "[REDACTED]" in result
+        assert "secret" not in result
+
+    def test_json_non_dict_response(self):
+        resp = self._make_response(json_data=[1, 2, 3])
+        result = http._truncate_response_content(resp)
+        assert "[1, 2, 3]" in str(result)
+
+    def test_non_json_response_returns_bytes(self):
+        resp = self._make_response(content=b"plain text response")
+        result = http._truncate_response_content(resp)
+        # _truncate on short bytes returns bytes unchanged
+        assert isinstance(result, bytes)
+        assert result == b"plain text response"
+
+    def test_non_json_response_no_content(self):
+        resp = self._make_response(content=None)
+        result = http._truncate_response_content(resp)
+        assert result == ""
+
+    def test_newlines_replaced_in_str_result(self):
+        resp = self._make_response(json_data={"key": "line1\nline2"})
+        result = http._truncate_response_content(resp)
+        assert isinstance(result, str)
+        assert "\n" not in result
+        assert "\\n" in result
+
+    def test_newlines_replaced_in_bytes_result(self):
+        resp = self._make_response(content=b"line1\nline2")
+        result = http._truncate_response_content(resp)
+        assert isinstance(result, bytes)
+        assert b"\n" not in result
+        assert b"\\n" in result

--- a/tests/unit/test_ipc.py
+++ b/tests/unit/test_ipc.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import struct
+from unittest.mock import patch
+
+import pytest
+
+from mapillary_tools import ipc
+
+
+class TestIPCWrite:
+    def test_write_rejects_non_serializable(self):
+        """json.dumps runs before the FD check, so non-serializable raises."""
+        with patch.object(ipc, "NODE_CHANNEL_FD", -1):
+            with pytest.raises(TypeError):
+                ipc._write({"func": lambda: None})
+
+    @patch("os.write")
+    def test_write_unix(self, mock_write):
+        """Unix path writes JSON + linesep directly to the fd."""
+        with patch.object(ipc, "NODE_CHANNEL_FD", 42), patch("os.name", "posix"):
+            ipc._write({"key": "value"})
+            mock_write.assert_called_once()
+            fd, raw = mock_write.call_args[0]
+            assert fd == 42
+            parsed = json.loads(raw.decode("utf-8").strip())
+            assert parsed == {"key": "value"}
+
+    @patch("os.write")
+    def test_write_windows(self, mock_write):
+        """Windows path prepends a 16-byte header: uint64(1) + uint64(payload_len)."""
+        with patch.object(ipc, "NODE_CHANNEL_FD", 42), patch("os.name", "nt"):
+            ipc._write({"key": "value"})
+            mock_write.assert_called_once()
+            fd, raw = mock_write.call_args[0]
+            assert fd == 42
+            # Verify the 16-byte header
+            header = raw[:16]
+            flag, payload_len = struct.unpack("<QQ", header)
+            assert flag == 1
+            # Verify the payload after the header is valid JSON
+            payload = raw[16:]
+            assert len(payload) == payload_len
+            parsed = json.loads(payload.decode("utf-8").strip())
+            assert parsed == {"key": "value"}


### PR DESCRIPTION
   ## Summary
  - Add 92 unit tests across 6 new test files
  - Unit test coverage increases from 65% to 67%
  - Targets modules with the lowest coverage:
    - `serializer/gpx.py`: 32% → 99%
    - `gpmf/gpmf_gps_filter.py`: 22% → 97%
    - `gpmf/gps_filter.py`: 68% → 94%
    - `history.py`: 59% → 81%
    - `ipc.py`: 0% → 71%
    - `api_v4.py`: 33% → 68%
    - `http.py`: 23% → 50%

  ## Test plan
  - All 629 unit tests pass (537 existing + 92 new)
  - Coverage measured with `coverage run -m pytest tests/unit && coverage combine && coverage report`