### PR TITLE
Fix exiftool_xml GPS epoch times for per-sample timestamps

### DIFF
--- a/mapillary_tools/exiftool_read_video.py
+++ b/mapillary_tools/exiftool_read_video.py
@@ -156,7 +156,12 @@ def _aggregate_epoch_times(
                 or []
             )
         ]
-        if len(gps_epoch_times) != expected_length:
+        if len(gps_epoch_times) == 1 and expected_length > 1:
+            # Some cameras (e.g. GoPro MAX) store a single GPSDateTime per sample
+            # shared across all the GPS coordinates in that sample. Broadcast the
+            # single epoch time to every coordinate to match the native parser.
+            gps_epoch_times = gps_epoch_times * expected_length
+        elif len(gps_epoch_times) != expected_length:
             LOG.warning(
                 "Found different number of GPS epoch times %d and coordinates %d",
                 len(gps_epoch_times),

--- a/tests/unit/test_exiftool_read_video.py
+++ b/tests/unit/test_exiftool_read_video.py
@@ -516,7 +516,10 @@ class TestAggregateGpsTrack:
         assert len(track) == 1
         assert track[0].ground_speed == pytest.approx(52.7561)
 
-    def test_gps_time_tag_length_mismatch_falls_back_to_none(self):
+    def test_single_gps_time_tag_is_broadcast_to_all_points(self):
+        # Some cameras (e.g. GoPro MAX) store a single GPSDateTime per sample
+        # shared across all the GPS coordinates in that sample. The single epoch
+        # time should be broadcast to every coordinate.
         texts = {
             expand_tag("QuickTime:GPSLongitude"): ["28.0", "29.0"],
             expand_tag("QuickTime:GPSLatitude"): ["37.0", "38.0"],
@@ -536,7 +539,33 @@ class TestAggregateGpsTrack:
             gps_time_tag="QuickTime:GPSTimeStamp",
         )
         assert len(track) == 2
-        # Mismatch in gps_time_tag length: epoch_time falls back to None
+        # 2019:09:02 10:00:10Z broadcast to both points
+        for p in track:
+            assert p.epoch_time == pytest.approx(1567418410.0)
+
+    def test_gps_time_tag_length_mismatch_falls_back_to_none(self):
+        texts = {
+            expand_tag("QuickTime:GPSLongitude"): ["28.0", "29.0"],
+            expand_tag("QuickTime:GPSLatitude"): ["37.0", "38.0"],
+            expand_tag("QuickTime:GPSDateTime"): [
+                "2019:09:02 10:00:00Z",
+                "2019:09:02 10:00:01Z",
+            ],
+            expand_tag("QuickTime:GPSTimeStamp"): [
+                "2019:09:02 10:00:10Z",
+                "2019:09:02 10:00:11Z",
+                "2019:09:02 10:00:12Z",
+            ],
+        }
+        track = _aggregate_gps_track(
+            texts,
+            time_tag="QuickTime:GPSDateTime",
+            lon_tag="QuickTime:GPSLongitude",
+            lat_tag="QuickTime:GPSLatitude",
+            gps_time_tag="QuickTime:GPSTimeStamp",
+        )
+        assert len(track) == 2
+        # Genuine mismatch (3 vs 2) in gps_time_tag length: epoch_time falls back to None
         for p in track:
             assert p.epoch_time is None
 


### PR DESCRIPTION
## Summary

Fixes 4 failing integration tests where the `exiftool_xml` / `exiftool_runtime` geotag source produced GPS tracks that diverged from the `native` source.

Cameras like the **GoPro MAX** store a single `GPSDateTime` per *sample*, shared across all (~17) GPS coordinates in that sample. The exiftool XML parser discarded these timestamps (set `epoch_time` to `None`) because the epoch-time count (1) didn't match the coordinate count (~17), while the native parser broadcasts the single sample timestamp to every coordinate.

This caused `MAPGPSTrack` to contain `None` epoch times under `exiftool_xml` but real timestamps under `native`, failing the exact-equality assertion in `assert_descs_exact_equal`.

## Fix

In `_aggregate_epoch_times`, when there is exactly one GPS epoch time for multiple coordinates, broadcast it to every coordinate (matching the native parser). Genuine length mismatches (e.g. 3 vs 2) still fall back to `None` with a warning.

## Tests

- All 52 integration tests pass (previously 4 failing):
  - `test_process_geotag_with_exiftool_xml`
  - `test_process_geotag_with_exiftool_xml_pattern`
  - `test_process_geotag_everything_with_exiftool_runtime`
  - `test_process_video_geotag_source_with_exiftool_runtime`
- Updated the unit test that locked in the old discard-on-mismatch behavior to assert the new broadcast behavior, and added a separate case for genuine (3-vs-2) mismatches that still fall back to `None`.
- `mypy` and `ruff` clean.